### PR TITLE
Support type = "rect"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ New features:
   support, first raised in #2, so that a boxplot is automatically plotted if a
   numeric is plotted against a factor. (#154 @grantmcdermott)
   - `type = "polypath`. (#159 @grantmcdermott)
+  - `type = "rect"`. (#161 @grantmcdermott)
 
 Misc:
 

--- a/R/draw_legend.R
+++ b/R/draw_legend.R
@@ -166,10 +166,10 @@ draw_legend = function(
   ) {
     legend_args[["pt.cex"]] = cex
   }
-  if (type %in% c("ribbon", "polygon", "polypath", "boxplot") || isTRUE(gradient)) {
+  if (type %in% c("rect", "ribbon", "polygon", "polypath", "boxplot") || isTRUE(gradient)) {
     legend_args[["pch"]] = 22
     if (is.null(legend_args[["pt.cex"]])) legend_args[["pt.cex"]] = 3.5
-    if (is.null(legend_args[["pt.lwd"]]) && (!is.null(type) && !(type %in% c("polygon", "polypath", "boxplot")))) {
+    if (is.null(legend_args[["pt.lwd"]]) && (!is.null(type) && !(type %in% c("rect", "polygon", "polypath", "boxplot")))) {
       legend_args[["pt.lwd"]] = 0
     }
     if (is.null(legend_args[["y.intersp"]])) legend_args[["y.intersp"]] = 1.25

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1370,7 +1370,7 @@ tinyplot.default = function(
       
       # empty plot flag
       empty_plot = FALSE
-      if (type=="n" || (length(xx)==0) && type!="rect") {
+      if (type=="n" || ((length(xx)==0) && type!="rect")) {
         empty_plot = TRUE
       }
       

--- a/inst/tinytest/_tinysnapshot/rect_by_fill.svg
+++ b/inst/tinytest/_tinysnapshot/rect_by_fill.svg
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<image width='18.00' height='86.40' x='465.09' y='205.84' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAABkCAYAAABHLFpgAAAAjElEQVQYlXWKsXHEQAzEQPDkwD24Ilf3Dd86kHSW9PMJB8CS359X3FI8zwg4dvqgncLBOTRgBxwsheOlC+yqRWBXTvJsCrb/Q67tQp3Vcm1vOo9mP2i+EWNi9cQaE7lQjoH7umtnae7tMQSRpTeKtVodf+lCWsTCtIdGke47DUw3stPAuCG9YfzC6Td/l79JGkcdgJAAAAAASUVORK5CYII='/>
+<text x='483.09' y='296.37' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='10.01px' lengthAdjust='spacingAndGlyphs'> 0</text>
+<text x='483.09' y='274.55' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'> 10</text>
+<text x='483.09' y='253.61' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'> 20</text>
+<text x='483.09' y='231.79' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'> 30</text>
+<text x='483.09' y='209.97' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'> 40</text>
+<text x='483.09' y='296.37' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='483.09' y='274.55' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='483.09' y='253.61' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='483.09' y='231.79' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='483.09' y='209.97' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='465.09' y='191.44' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='2.66px' lengthAdjust='spacingAndGlyphs'>i</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0NDcuODF8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='447.81' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0NDcuODF8MC4wMHw1MDQuMDA=)'>
+<text x='253.43' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='86.07px' lengthAdjust='spacingAndGlyphs'>[100 + i, 150 + i]</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='86.07px' lengthAdjust='spacingAndGlyphs'>[300 + i, 380 + i]</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='73.44' y1='430.56' x2='393.42' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='73.44' y1='430.56' x2='73.44' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='153.43' y1='430.56' x2='153.43' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='233.43' y1='430.56' x2='233.43' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='313.42' y1='430.56' x2='313.42' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='393.42' y1='430.56' x2='393.42' y2='437.76' style='stroke-width: 0.75;' />
+<text x='73.44' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='153.43' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text x='233.43' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>140</text>
+<text x='313.42' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>160</text>
+<text x='393.42' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>180</text>
+<line x1='59.04' y1='416.80' x2='59.04' y2='72.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='416.80' x2='51.84' y2='416.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='359.47' x2='51.84' y2='359.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='302.13' x2='51.84' y2='302.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='244.80' x2='51.84' y2='244.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='187.47' x2='51.84' y2='187.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='130.13' x2='51.84' y2='130.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='72.80' x2='51.84' y2='72.80' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,416.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text transform='translate(41.76,359.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>320</text>
+<text transform='translate(41.76,302.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>340</text>
+<text transform='translate(41.76,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>360</text>
+<text transform='translate(41.76,187.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>380</text>
+<text transform='translate(41.76,130.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text transform='translate(41.76,72.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>420</text>
+<polygon points='59.04,430.56 447.81,430.56 447.81,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDQ3LjgxfDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='388.77' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDQ3LjgxfDU5LjA0fDQzMC41Ng==)'>
+<rect x='73.44' y='187.47' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #E7D39A; fill: #E7D39A; fill-opacity: 0.20;' />
+<rect x='89.44' y='176.00' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #EFBB6C; fill: #EFBB6C; fill-opacity: 0.20;' />
+<rect x='105.44' y='164.53' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #F2A05E; fill: #F2A05E; fill-opacity: 0.20;' />
+<rect x='121.44' y='153.07' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #F38464; fill: #F38464; fill-opacity: 0.20;' />
+<rect x='137.43' y='141.60' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #EF6575; fill: #EF6575; fill-opacity: 0.20;' />
+<rect x='153.43' y='130.13' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #E64886; fill: #E64886; fill-opacity: 0.20;' />
+<rect x='169.43' y='118.67' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #D13094; fill: #D13094; fill-opacity: 0.20;' />
+<rect x='185.43' y='107.20' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #B71C9B; fill: #B71C9B; fill-opacity: 0.20;' />
+<rect x='201.43' y='95.73' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #9A0F9C; fill: #9A0F9C; fill-opacity: 0.20;' />
+<rect x='217.43' y='84.27' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #771399; fill: #771399; fill-opacity: 0.20;' />
+<rect x='233.43' y='72.80' width='199.99' height='229.33' style='stroke-width: 0.75; stroke: #4B1D91; fill: #4B1D91; fill-opacity: 0.20;' />
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/rect_simple.svg
+++ b/inst/tinytest/_tinysnapshot/rect_simple.svg
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='86.07px' lengthAdjust='spacingAndGlyphs'>[100 + i, 150 + i]</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='86.07px' lengthAdjust='spacingAndGlyphs'>[300 + i, 380 + i]</text>
+<line x1='74.40' y1='430.56' x2='415.73' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='74.40' y1='430.56' x2='74.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='159.73' y1='430.56' x2='159.73' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='245.07' y1='430.56' x2='245.07' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='330.40' y1='430.56' x2='330.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='415.73' y1='430.56' x2='415.73' y2='437.76' style='stroke-width: 0.75;' />
+<text x='74.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='159.73' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text x='245.07' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>140</text>
+<text x='330.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>160</text>
+<text x='415.73' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>180</text>
+<line x1='59.04' y1='416.80' x2='59.04' y2='72.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='416.80' x2='51.84' y2='416.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='359.47' x2='51.84' y2='359.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='302.13' x2='51.84' y2='302.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='244.80' x2='51.84' y2='244.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='187.47' x2='51.84' y2='187.47' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='130.13' x2='51.84' y2='130.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='72.80' x2='51.84' y2='72.80' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,416.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text transform='translate(41.76,359.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>320</text>
+<text transform='translate(41.76,302.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>340</text>
+<text transform='translate(41.76,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>360</text>
+<text transform='translate(41.76,187.47) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>380</text>
+<text transform='translate(41.76,130.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text transform='translate(41.76,72.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>420</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<rect x='74.40' y='187.47' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='91.47' y='176.00' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='108.53' y='164.53' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='125.60' y='153.07' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='142.67' y='141.60' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='159.73' y='130.13' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='176.80' y='118.67' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='193.87' y='107.20' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='210.93' y='95.73' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='228.00' y='84.27' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+<rect x='245.07' y='72.80' width='213.33' height='229.33' style='stroke-width: 0.75;' />
+</g>
+</svg>

--- a/inst/tinytest/test-rect.R
+++ b/inst/tinytest/test-rect.R
@@ -1,0 +1,30 @@
+source("helpers.R")
+using("tinysnapshot")
+
+f = function() {
+  i = 4*(0:10)
+  plt(
+    xmin = 100+i,
+    ymin = 300+i,
+    xmax = 150+i,
+    ymax = 380+i,
+    type = "rect"
+  )
+}
+expect_snapshot_plot(f, label = "rect_simple")
+
+f = function() {
+  i = 4*(0:10)
+  plt(
+    xmin = 100+i,
+    ymin = 300+i,
+    xmax = 150+i,
+    ymax = 380+i,
+    by = i,
+    type = "rect",
+    fill = 0.2,
+    palette = "agsunset"
+  )
+}
+expect_snapshot_plot(f, label = "rect_by_fill")
+

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -41,6 +41,8 @@ tinyplot(x, ...)
   alpha = NULL,
   cex = 1,
   restore.par = FALSE,
+  xmin = NULL,
+  xmax = NULL,
   ymin = NULL,
   ymax = NULL,
   ribbon.alpha = NULL,
@@ -349,9 +351,9 @@ setting to TRUE instead. See also \link{get_saved_par} for another option to
 recover the original \code{\link[graphics]{par}} settings, as well as
 longer discussion about the trade-offs involved.}
 
-\item{ymin, ymax}{minimum and maximum coordinates of interval plot types. Only
-used when the \code{type} argument is one of "pointrange", "errorbar", or
-"ribbon".}
+\item{xmin, xmax, ymin, ymax}{minimum and maximum coordinates of relevant area
+or interval plot types. Only used when the \code{type} argument is one of
+"pointrange", "errorbar", "ribbon", or "rect".}
 
 \item{ribbon.alpha}{numeric factor modifying the opacity alpha of any ribbon
 shading; typically in \verb{[0, 1]}. Only used when \code{type = "ribbon"}, or when


### PR DESCRIPTION
Closes #160.

Should also open the door up to other derivative plot types (most obviously histograms), as well as segments (which use a similar `xmin`.`ymin`,`xmax`,`ymax` coordinate logic).

Example: 

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot
```

``` r

i = 4*(0:10)

plt(
  xmin = 100+i,
  ymin = 300+i,
  xmax = 150+i,
  ymax = 380+i,
  by = i,
  type = "rect",
  fill = 0.3
)
```

![](https://i.imgur.com/z7no6lk.png)<!-- -->

<sup>Created on 2024-07-06 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>