### PR TITLE
Add `empty = <logical>` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,10 @@ where the formatting is also better._
 New features:
 
 - Support for additional plot types:
-  - `type = "n"`, i.e. empty plot. (#157 @grantmcdermott)
+  - `type = "n"`, i.e. empty plot. Since `type = "n"` implicitly assumes points,
+  which limits the type of legend that can be drawn alongside the empty plot, we
+  have also added a companion `empty` argument that can be used alongside any
+  plot type. (#157, #167 @grantmcdermott)
   - `type = "boxplot"`. Simultaneously enables `plt(numeric ~ factor)`
   support, first raised in #2, so that a boxplot is automatically plotted if a
   numeric is plotted against a factor. (#154 @grantmcdermott)

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -72,12 +72,20 @@
 #'   for lines, "b" for both points and lines, "c" for empty points joined by
 #'   lines, "o" for overplotted points and lines, "s" and "S" for stair steps,
 #'   and "h" for histogram-like vertical lines. Specifying "n" produces an empty
-#'   plot over the extent of the data, but with no internal elements.
+#'   plot over the extent of the data, but with no internal elements (see also
+#'   the `empty` argument below).
 #'   - Additional tinyplot types: "boxplot" for boxplots, "density" for
 #'   densities, "polygon" or "polypath" for polygons,  "pointrange" or"errorbar"
 #'   for segment intervals, and "ribbon" or "area" for polygon intervals (where
 #'   area plots are a special case of ribbon plots with `ymin` set to 0 and
 #'   `ymax` set to `y`; see below).
+#' @param empty logical indicating whether the interior plot region should be
+#'  left empty. The default is `FALSE`. Setting to `TRUE` has a similar effect
+#'  to invoking `type = "n"` above, except that any legend artifacts owing to a
+#'  particular plot type (e.g., lines for `type = "l"` or squares for
+#'  `type = "area"`) will still be drawn correctly alongside the empty plot. In
+#'  contrast,`type = "n"` implicitly assumes a scatterplot and so any legend
+#'  will only depict points.
 #' @param xmin,xmax,ymin,ymax minimum and maximum coordinates of relevant area
 #'   or interval plot types. Only used when the `type` argument is one of
 #'   "rect" or "segments" (where all four min-max coordinates are required), or
@@ -250,7 +258,7 @@
 #'  graphics windows.
 #' @param height numeric giving the plot height in inches. Same considerations as
 #'  `width` (above) apply, e.g. will default to `tpar("file.height")` if not
-#'  specified. 
+#'  specified.
 #' @param ... other graphical parameters. See \code{\link[graphics]{par}} or
 #'   the "Details" section of \code{\link[graphics]{plot}}.
 #'
@@ -489,6 +497,7 @@ tinyplot.default = function(
     file = NULL,
     width = NULL,
     height = NULL,
+    empty = FALSE,
     ...) {
   
   dots = list(...)
@@ -1372,7 +1381,7 @@ tinyplot.default = function(
       
       # empty plot flag
       empty_plot = FALSE
-      if (type=="n" || ((length(xx)==0) && !(type %in% c("rect","segments")))) {
+      if (isTRUE(empty) || type=="n" || ((length(xx)==0) && !(type %in% c("rect","segments")))) {
         empty_plot = TRUE
       }
       

--- a/inst/tinytest/_tinysnapshot/type_l_empty.svg
+++ b/inst/tinytest/_tinysnapshot/type_l_empty.svg
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='413.40' y1='237.60' x2='435.00' y2='237.60' style='stroke-width: 0.75;' />
+<line x1='413.40' y1='252.00' x2='435.00' y2='252.00' style='stroke-width: 0.75; stroke: #DF536B;' />
+<line x1='413.40' y1='266.40' x2='435.00' y2='266.40' style='stroke-width: 0.75; stroke: #61D04F;' />
+<text x='452.58' y='223.20' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.70px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text x='445.80' y='241.73' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='35.37px' lengthAdjust='spacingAndGlyphs'>setosa</text>
+<text x='445.80' y='256.13' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
+<text x='445.80' y='270.53' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.02px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHwzODguMjB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='388.20' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHwzODguMjB8MC4wMHw1MDQuMDA=)'>
+<text x='223.62' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.39px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.73px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='71.23' y1='430.56' x2='381.18' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='71.23' y1='430.56' x2='71.23' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='122.89' y1='430.56' x2='122.89' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='174.55' y1='430.56' x2='174.55' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='226.20' y1='430.56' x2='226.20' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='277.86' y1='430.56' x2='277.86' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='329.52' y1='430.56' x2='329.52' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='381.18' y1='430.56' x2='381.18' y2='437.76' style='stroke-width: 0.75;' />
+<text x='71.23' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='122.89' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='174.55' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='226.20' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='277.86' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='329.52' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='381.18' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='59.04' y1='397.69' x2='59.04' y2='63.24' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='397.69' x2='51.84' y2='397.69' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='349.91' x2='51.84' y2='349.91' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='302.13' x2='51.84' y2='302.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='254.36' x2='51.84' y2='254.36' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='206.58' x2='51.84' y2='206.58' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='158.80' x2='51.84' y2='158.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='111.02' x2='51.84' y2='111.02' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='63.24' x2='51.84' y2='63.24' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,397.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text transform='translate(41.76,349.91) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text transform='translate(41.76,302.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text transform='translate(41.76,254.36) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text transform='translate(41.76,206.58) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text transform='translate(41.76,158.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text transform='translate(41.76,111.02) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text transform='translate(41.76,63.24) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='59.04,430.56 388.20,430.56 388.20,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+</svg>

--- a/inst/tinytest/test-misc.R
+++ b/inst/tinytest/test-misc.R
@@ -6,11 +6,15 @@ f = function () {
   tinyplot(Sepal.Length ~ Petal.Length, data = iris, type = "n")
 }
 expect_snapshot_plot(f, label = "type_n")
-# empty plot(s)
 f = function () {
   tinyplot(Sepal.Length ~ Petal.Length | Species, data = iris, type = "n")
 }
 expect_snapshot_plot(f, label = "type_n_by")
+f = function () {
+  tinyplot(Sepal.Length ~ Petal.Length | Species, data = iris, type = "l", empty = TRUE)
+}
+expect_snapshot_plot(f, label = "type_l_empty")
+
 
 # log axes
 f = function() {

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -50,6 +50,7 @@ tinyplot(x, ...)
   file = NULL,
   width = NULL,
   height = NULL,
+  empty = FALSE,
   ...
 )
 
@@ -186,7 +187,8 @@ should be taken. A matrix is converted to a data frame.}
 for lines, "b" for both points and lines, "c" for empty points joined by
 lines, "o" for overplotted points and lines, "s" and "S" for stair steps,
 and "h" for histogram-like vertical lines. Specifying "n" produces an empty
-plot over the extent of the data, but with no internal elements.
+plot over the extent of the data, but with no internal elements (see also
+the \code{empty} argument below).
 \item Additional tinyplot types: "boxplot" for boxplots, "density" for
 densities, "polygon" or "polypath" for polygons,  "pointrange" or"errorbar"
 for segment intervals, and "ribbon" or "area" for polygon intervals (where
@@ -399,6 +401,14 @@ graphics windows.}
 \item{height}{numeric giving the plot height in inches. Same considerations as
 \code{width} (above) apply, e.g. will default to \code{tpar("file.height")} if not
 specified.}
+
+\item{empty}{logical indicating whether the interior plot region should be
+left empty. The default is \code{FALSE}. Setting to \code{TRUE} has a similar effect
+to invoking \code{type = "n"} above, except that any legend artifacts owing to a
+particular plot type (e.g., lines for \code{type = "l"} or squares for
+\code{type = "area"}) will still be drawn correctly alongside the empty plot. In
+contrast,\code{type = "n"} implicitly assumes a scatterplot and so any legend
+will only depict points.}
 
 \item{formula}{a \code{formula} that optionally includes grouping variable(s)
 after a vertical bar, e.g. \code{y ~ x | z}. One-sided formulae are also


### PR DESCRIPTION
Closes #166.

Allows users to produce empty plots, but still honour the type of legend that would have been produced by non-point type plots.

``` r
tinyplot::plt(Sepal.Length ~ Petal.Length | Species, data = iris, type = "l", empty = TRUE)
```

![](https://i.imgur.com/uxvH1Mo.png)<!-- -->

``` r

tinyplot::plt(~Petal.Length | Species, data = iris, type = "density", fill = "by", empty = TRUE)
```

![](https://i.imgur.com/1bWMuxx.png)<!-- -->

<sup>Created on 2024-07-15 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>