### PR TITLE
type = NULL

### DIFF
--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -8,10 +8,20 @@ sanitize_ribbon.alpha = function(ribbon.alpha) {
 
 
 sanitize_type = function(type, x, y) {
-    # enforce boxplot type for y ~ factor(x)
-    if (!is.null(x) && is.factor(x) && !is.factor(y) && !identical(type, "boxplot")) {
-        type = "boxplot"
-        warning('The `type` argument was changed to "boxplot" automatically because `x` is a factor but not `y`.', call. = FALSE)
+    # # enforce boxplot type for y ~ factor(x)
+    # if (!is.null(x) && is.factor(x) && !is.factor(y) && !identical(type, "boxplot")) {
+    #     type = "boxplot"
+    #     warning('The `type` argument was changed to "boxplot" automatically because `x` is a factor but not `y`.', call. = FALSE)
+    # }
+    if (is.null(type)) {
+        # enforce boxplot type for y ~ factor(x)
+        if (!is.null(x) && is.factor(x) && !is.factor(y)) {
+            type = "boxplot"
+        } else {
+            type = "p"
+        }
+    } else if (type %in% c("j", "jitter")) {
+        type = "jitter"
     }
     return(type)
 }

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -6,13 +6,7 @@ sanitize_ribbon.alpha = function(ribbon.alpha) {
 
 
 
-
 sanitize_type = function(type, x, y) {
-    # # enforce boxplot type for y ~ factor(x)
-    # if (!is.null(x) && is.factor(x) && !is.factor(y) && !identical(type, "boxplot")) {
-    #     type = "boxplot"
-    #     warning('The `type` argument was changed to "boxplot" automatically because `x` is a factor but not `y`.', call. = FALSE)
-    # }
     if (is.null(type)) {
         # enforce boxplot type for y ~ factor(x)
         if (!is.null(x) && is.factor(x) && !is.factor(y)) {
@@ -20,6 +14,8 @@ sanitize_type = function(type, x, y) {
         } else {
             type = "p"
         }
+    } else if (type %in% c("hist", "histogram")) {
+        type = "histogram"
     } else if (type %in% c("j", "jitter")) {
         type = "jitter"
     }

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1485,7 +1485,7 @@ tinyplot.formula = function(
   }
 
   ## nice axis and legend labels
-  if (!is.null(type) && type == c("hist", "histogram")) {
+  if (!is.null(type) && type %in% c("hist", "histogram")) {
     if (is.null(ylab)) ylab = "Frequency"
     if (is.null(xlab)) xlab = names(mf)[x_loc]
   } else if (no_y) {

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -68,8 +68,8 @@
 #' @param data a data.frame (or list) from which the variables in formula
 #'   should be taken. A matrix is converted to a data frame.
 #' @param type character string giving the type of plot desired. If no argument
-#'   is provided, then the plot type will default to something that makes sense
-#'   given the nature of `x` and `y` (i.e., usually `"p"`). Options are:
+#'   is provided, then the plot type will default to something sensible for the
+#'   type of `x` and `y` inputs (i.e., usually `"p"`). Options are:
 #'   - The same set of 1-character values supported by
 #'   \code{\link[graphics]{plot}}: `"p"` for points, `"l"` for lines, `"b"` for
 #'   both points and lines, `"c"` for empty points joined by lines, `"o"` for
@@ -583,7 +583,7 @@ tinyplot.default = function(
       y_dep = paste0("[", ymin_dep, ", ", ymax_dep, "]")
       y = rep(NA, length(x))
       if (is.null(ylim)) ylim = range(c(ymin, ymax))
-    } else if (!type %in% c("density", "hist", "histogram")) {
+    } else if (!type %in% c("density", "histogram")) {
       y = x
       x = seq_along(x)
       xlab = "Index"
@@ -604,7 +604,7 @@ tinyplot.default = function(
     return(do.call(tinyplot.density, args = fargs))
   }
 
-  if (type %in% c("hist", "histogram")) {
+  if (type == "histogram") {
     fargs = histogram_args(
       x = x, by = by, facet = facet, facet_by = facet_by, dots = dots,
       ylab = ylab, col = col, bg = bg, fill = fill, ribbon.alpha = ribbon.alpha)
@@ -1485,7 +1485,7 @@ tinyplot.formula = function(
   }
 
   ## nice axis and legend labels
-  if (!is.null(type) && type %in% c("hist", "histogram")) {
+  if (!is.null(type) && type == c("hist", "histogram")) {
     if (is.null(ylab)) ylab = "Frequency"
     if (is.null(xlab)) xlab = names(mf)[x_loc]
   } else if (no_y) {

--- a/inst/tinytest/helpers.R
+++ b/inst/tinytest/helpers.R
@@ -2,8 +2,8 @@ library(tinytest)
 library(tinysnapshot)
 
 # # Skip tests if not on Linux
-ON_LINUX = Sys.info()["sysname"] == "Linux"
-if (!ON_LINUX) exit_file("Linux snapshots")
+# ON_LINUX = Sys.info()["sysname"] == "Linux"
+# if (!ON_LINUX) exit_file("Linux snapshots")
 
 options("tinysnapshot_os" = "Linux")
 options("tinysnapshot_device" = "svglite")

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -44,7 +44,7 @@ tinyplot(x, ...)
   facet = NULL,
   facet.args = NULL,
   data = NULL,
-  type = "p",
+  type = NULL,
   xlim = NULL,
   ylim = NULL,
   log = "",
@@ -86,7 +86,7 @@ tinyplot(x, ...)
   data = parent.frame(),
   facet = NULL,
   facet.args = NULL,
-  type = "p",
+  type = NULL,
   xlim = NULL,
   ylim = NULL,
   main = NULL,
@@ -175,7 +175,9 @@ and background. Default values for these arguments are inherited from
 features globally for all \code{tinyplot} plots.
 }}
 
-\item{type}{character string giving the type of plot desired. Options are:
+\item{type}{character string giving the type of plot desired. If no argument
+is provided, then the plot type will default to something sensible for the
+type of \code{x} and \code{y} inputs (i.e., usually \code{"p"}). Options are:
 \itemize{
 \item The same set of 1-character values supported by
 \code{\link[graphics]{plot}}: \code{"p"} for points, \code{"l"} for lines, \code{"b"} for


### PR DESCRIPTION
Closes #178.

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot
```

``` r
plt(Sepal.Length ~ Species, iris, type = "jitter")
```

![](https://i.imgur.com/Vrh2E3P.png)<!-- -->

<sup>Created on 2024-07-30 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

(Beyond this specific example, setting  `type = NULL` rather than `type = "p"` simultaneously allows for more sensible default type override/assignment down the road). 
