### PR TITLE
Fix duplicate density call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tinyplot
 Type: Package
 Title: Lightweight Extension of the Base R Graphics System
-Version: 0.2.0
+Version: 0.2.0.99
 Date: 2024-07-30
 Authors@R: 
   c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ _If you are viewing this file on CRAN, please check the
 [latest NEWS](https://grantmcdermott.com/tinyplot/NEWS.html) on our website
 where the formatting is also better._
 
+## 0.2.0.99 (development version)
+
+Bug fixes:
+
+- Fix duplicate plots produced with `type = "density"`, which was a regression
+accidentally introduced in v0.2.0 (#187 @grantmcdermott)
+
 ## 0.2.0
 
 New features:

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -600,7 +600,6 @@ tinyplot.default = function(
   if (type == "density") {
     fargs = mget(ls(environment(), sorted = FALSE))
     fargs = density_args(fargs = fargs, dots = dots, by_dep = by_dep)
-    do.call(tinyplot.density, args = fargs)
     return(do.call(tinyplot.density, args = fargs))
   }
 


### PR DESCRIPTION
Closes #186.

Culprit was duplicate `do.call(...)` lines here: https://github.com/grantmcdermott/tinyplot/blob/f5436fcc9c1b6d206b4cd9b2aee1de169031b232/R/tinyplot.R#L603-L604

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot

plt(
  ~ Petal.Length | Species,
  data = iris,
  type = "density",
  palette = "dark", fill = "by",
  grid = TRUE,
  main = "Distribution of petal lengths by species"
)
```

![](https://i.imgur.com/pBjwaox.png)<!-- -->

<sup>Created on 2024-08-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>