### PR TITLE
Fine control of axis types in axes/xaxt/yaxt

### DIFF
--- a/R/tinyAxis.R
+++ b/R/tinyAxis.R
@@ -1,0 +1,20 @@
+## auxiliary Axis() interface with different parameter combinations based on type
+tinyAxis = function(x = NULL, ..., type = "standard") {
+  type = match.arg(type, c("standard", "none", "labels", "ticks", "axis"))
+  if (type == "none") {
+    invisible(numeric(0L))
+  } else {
+    args = list(x = x, ...)
+    if (type == "labels") {
+      args$tick = FALSE
+    } else if (type == "ticks") {
+      args$lwd = 0
+      if (!("lwd.ticks" %in% names(args))) args$lwd.ticks = 1
+    } else if (type == "axis") {
+      args$lwd.ticks = 0
+    } else {
+      args$tick = TRUE
+    }
+    do.call("Axis", args)
+  }
+}

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -531,7 +531,7 @@ tinyplot.default = function(
 
   ## handle defaults of axes, xaxt, yaxt, frame.plot
   ## - convert axes to character if necessary
-  ## - set defaults of xaxt/yaxt if these are NULL
+  ## - set defaults of xaxt/yaxt (if these are NULL) based on axes
   ## - set logical axes based on xaxt/yaxt
   ## - set frame.plot default based on xaxt/yaxt
   if (!is.character(axes)) axes = if (isFALSE(axes)) "none" else "standard"
@@ -543,17 +543,6 @@ tinyplot.default = function(
   yaxt = substr(match.arg(yaxt, axis_types), 1L, 1L)
   axes = any(c(xaxt, yaxt) != "n")
   if (is.null(frame.plot) || !is.logical(frame.plot)) frame.plot = all(c(xaxt, yaxt) %in% c("s", "a"))
-
-  ## auxiliary function with axis type
-  ## (could also become an unexported function in the package)
-  tinyAxis = function(x = NULL, ..., type = "standard") {
-    switch(substr(type, 1L, 1L),
-      "n" = invisible(numeric(0L)),
-      "l" = Axis(x = x, ..., tick = FALSE),
-      "t" = Axis(x = x, ..., lwd = 0, lwd.ticks = 1),
-      "a" = Axis(x = x, ..., lwd.ticks = 0),
-      Axis(x = x, ...))
-  }
 
   # Write plot to output file or window with fixed dimensions
   setup_device(file = file, width = width, height = height)

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -78,6 +78,8 @@ tinyplot(x, ...)
   width = NULL,
   height = NULL,
   empty = FALSE,
+  xaxt = NULL,
+  yaxt = NULL,
   ...
 )
 
@@ -217,9 +219,8 @@ the range of the \code{finite} values to be plotted should be used.}
 \item{ann}{a logical value indicating whether the default annotation (title
 and x and y axis labels) should appear on the plot.}
 
-\item{axes}{a logical value indicating whether both axes should be drawn on
-the plot. Use \verb{graphical parameter} "xaxt" or "yaxt" to suppress just one of
-the axes.}
+\item{axes}{logical or character. Should axes be drawn (\code{TRUE} or \code{FALSE})?
+Or alternatively what type of axes should be drawn: \verb{"standard" (with axis, ticks, and labels; equivalent to }TRUE\verb{), "none" (no axes; equivalent to }FALSE\verb{), }"ticks"\verb{(only ticks and labels without axis line),}"labels"\verb{(only labels without ticks and axis line),}"axis"\verb{(only axis line and labels but no ticks). To control this separately for the two axes, use the character specifications for}xaxt\code{and/or}yaxt`.}
 
 \item{frame.plot}{a logical indicating whether a box should be drawn around
 the plot. Can also use \code{frame} as an acceptable argument alias.}
@@ -419,6 +420,9 @@ particular plot type (e.g., lines for \code{type = "l"} or squares for
 \code{type = "area"}) will still be drawn correctly alongside the empty plot. In
 contrast,\code{type = "n"} implicitly assumes a scatterplot and so any legend
 will only depict points.}
+
+\item{xaxt, yaxt}{character specifying the type of x-axis and y-axis, respectively.
+See \code{axes} for the possible values.}
 
 \item{formula}{a \code{formula} that optionally includes grouping variable(s)
 after a vertical bar, e.g. \code{y ~ x | z}. One-sided formulae are also

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -54,7 +54,7 @@ tinyplot(x, ...)
   ylab = NULL,
   ann = par("ann"),
   axes = TRUE,
-  frame.plot = axes,
+  frame.plot = NULL,
   asp = NA,
   grid = NULL,
   palette = NULL,
@@ -97,7 +97,7 @@ tinyplot(x, ...)
   ylab = NULL,
   ann = par("ann"),
   axes = TRUE,
-  frame.plot = axes,
+  frame.plot = NULL,
   asp = NA,
   grid = NULL,
   pch = NULL,
@@ -223,7 +223,9 @@ and x and y axis labels) should appear on the plot.}
 Or alternatively what type of axes should be drawn: \verb{"standard" (with axis, ticks, and labels; equivalent to }TRUE\verb{), "none" (no axes; equivalent to }FALSE\verb{), }"ticks"\verb{(only ticks and labels without axis line),}"labels"\verb{(only labels without ticks and axis line),}"axis"\verb{(only axis line and labels but no ticks). To control this separately for the two axes, use the character specifications for}xaxt\code{and/or}yaxt`.}
 
 \item{frame.plot}{a logical indicating whether a box should be drawn around
-the plot. Can also use \code{frame} as an acceptable argument alias.}
+the plot. Can also use \code{frame} as an acceptable argument alias.
+The default is to draw a frame if both axis types (set via \code{axes}, \code{xaxt},
+or \code{yaxt}) include axis lines.}
 
 \item{asp}{the y/xy/x aspect ratio, see \code{plot.window}.}
 


### PR DESCRIPTION
As discussed in https://github.com/grantmcdermott/tinyplot/issues/182 I have tried to implement character specifications of different axis types. The docs of the relevant arguments in `tinyplot.default` now say:

  * `axes`: logical or character. Should axes be drawn (`TRUE` or `FALSE`)? Or alternatively what type of axes should be drawn: `"standard"` (with axis, ticks, and labels; equivalent to `TRUE`), `"none"` (no axes; equivalent to `FALSE`), `"ticks"` (only ticks and labels without axis line), `"labels"` (only labels without ticks and axis line), `"axis"` (only axis line and labels but no ticks). To control this separately for the two axes, use the character specifications for `xaxt` and/or `yaxt`.
* `xaxt`, `yaxt`: character specifying the type of x-axis and y-axis, respectively. See `axes` for the possible values.

Illustration:

```
library("tinyplot")
x <- 0:100/10
y <- sin(x)
tinyplot(y ~ x, type = "l", lwd = 2, col = "steelblue", grid = TRUE, main = 'default')
tinyplot(y ~ x, type = "l", lwd = 2, col = "steelblue", grid = TRUE, main = 'axes = "ticks"', axes = "ticks")
tinyplot(y ~ x, type = "l", lwd = 2, col = "steelblue", grid = TRUE, main = 'axes = "labels"', axes = "labels")
tinyplot(y ~ x, type = "l", lwd = 2, col = "steelblue", grid = TRUE, main = 'axes = "axis"', axes = "axis")
tinyplot(y ~ x, type = "l", lwd = 2, col = "steelblue", grid = TRUE, main = 'xaxt = "ticks", yaxt = "labels"', xaxt = "ticks", yaxt = "labels")
tinyplot(y ~ x, type = "l", lwd = 2, col = "steelblue", grid = TRUE, main = 'axes = "none", yaxt = "standard"', axes = "none", yaxt = "standard")
```

![Different tinyplot axes definitions](https://github.com/user-attachments/assets/2ab824d4-716e-449a-bd61-50a9d2ae090a)

Note that the plot in the bottom left panel is maybe unexpected. The reason is that `frame.plot` is solely selected based on `axes` (which is `TRUE` here) and not based on `xaxt`/`yaxt`. One could consider changing that but I felt that the selection of the defaults is already involved enough for a first proposal.

Feel free to make any changes or discard the PR if it's not useful (in this way).