### PR TITLE
Fix typo in docs that affected the formatting on the website

### DIFF
--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -113,7 +113,7 @@
 #' @param ann a logical value indicating whether the default annotation (title
 #'   and x and y axis labels) should appear on the plot.
 #' @param axes logical or character. Should axes be drawn (`TRUE` or `FALSE`)?
-#'   Or alternatively what type of axes should be drawn: `"standard" (with
+#'   Or alternatively what type of axes should be drawn: "standard" (with
 #'   axis, ticks, and labels; equivalent to `TRUE`), "none" (no axes;
 #'   equivalent to `FALSE`), `"ticks"` (only ticks and labels without axis line),
 #'   `"labels"` (only labels without ticks and axis line), `"axis"` (only axis

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -220,7 +220,12 @@ the range of the \code{finite} values to be plotted should be used.}
 and x and y axis labels) should appear on the plot.}
 
 \item{axes}{logical or character. Should axes be drawn (\code{TRUE} or \code{FALSE})?
-Or alternatively what type of axes should be drawn: \verb{"standard" (with axis, ticks, and labels; equivalent to }TRUE\verb{), "none" (no axes; equivalent to }FALSE\verb{), }"ticks"\verb{(only ticks and labels without axis line),}"labels"\verb{(only labels without ticks and axis line),}"axis"\verb{(only axis line and labels but no ticks). To control this separately for the two axes, use the character specifications for}xaxt\code{and/or}yaxt`.}
+Or alternatively what type of axes should be drawn: "standard" (with
+axis, ticks, and labels; equivalent to \code{TRUE}), "none" (no axes;
+equivalent to \code{FALSE}), \code{"ticks"} (only ticks and labels without axis line),
+\code{"labels"} (only labels without ticks and axis line), \code{"axis"} (only axis
+line and labels but no ticks). To control this separately for the two
+axes, use the character specifications for \code{xaxt} and/or \code{yaxt}.}
 
 \item{frame.plot}{a logical indicating whether a box should be drawn around
 the plot. Can also use \code{frame} as an acceptable argument alias.


### PR DESCRIPTION
This lonely backtick in the R file generated several `\verb{}` tags in the Rd file (cf https://github.com/etiennebacher/altdoc/issues/289#issuecomment-2285515243), which then messed up the formatting of the arguments section:

https://grantmcdermott.com/tinyplot/man/tinyplot.html#arguments

![image](https://github.com/user-attachments/assets/73a101f7-be98-4e15-86af-f8e939044bcb)

Fixing this typo also fixes the formatting on the website.

Related to https://github.com/etiennebacher/altdoc/issues/289