### PR TITLE
Coerce x/y/by from character to factor

### DIFF
--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -587,9 +587,14 @@ tinyplot.default = function(
   }
   by_dep = deparse1(substitute(by))
   
+  ## coerce character variables to factors
+  if (!is.null(x) && is.character(x)) x <- factor(x)
+  if (!is.null(y) && is.character(y)) y <- factor(y)
+  if (!is.null(by) && is.character(by)) by <- factor(by)
+
   # flag if x==by (currently only used if type = "boxplot")
   x_by = identical(x, by)
-  
+
   facet_dep = deparse1(substitute(facet))
   # flag if facet==by
   facet_by = FALSE

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -588,9 +588,9 @@ tinyplot.default = function(
   by_dep = deparse1(substitute(by))
   
   ## coerce character variables to factors
-  if (!is.null(x) && is.character(x)) x <- factor(x)
-  if (!is.null(y) && is.character(y)) y <- factor(y)
-  if (!is.null(by) && is.character(by)) by <- factor(by)
+  if (!is.null(x) && is.character(x)) x = factor(x)
+  if (!is.null(y) && is.character(y)) y = factor(y)
+  if (!is.null(by) && is.character(by)) by = factor(by)
 
   # flag if x==by (currently only used if type = "boxplot")
   x_by = identical(x, by)


### PR DESCRIPTION
Fixes #217

**Summary:** In `tinyplot.default` the `x`, `y`, and `by` variables are turned into factors if they are character variables. This is done early on in the function but after all `deparse1(substitute(...))` calls because the coercion would evaluate the variables obviously.

**Caveat:** In the modular future we might have tinyplot types which want to draw character variables in some way. As long as the type "knows" that, it's not yet a killer argument. The plot type could coerce back with `as.character()` and end up with the original variable. However, if that plot type would do somewhat different things for character variables and factor variables, then the design decision from this PR would prevent that.