### PR TITLE
Support `grid()` args in tpar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,9 @@ types enable a variety of additional features. (#222 @vincentarelbundock)
   of the x and y axes. This should work regardless of plot type, e.g.
   `plt(~Sepal.Length | Species, data = iris, type = "density", flip = TRUE)`.
   (#216 @grantmcdermott)
+- `tpar()` gains additional `grid.col`, `grid.lty`, and `grid.lwd` arguments for
+  fine-grained control over the appearance of the default panel grid when
+  `plt(..., grid = TRUE)` is called. (#237 @grantmcdermott)
 
 Bug fixes:
 

--- a/R/facet.R
+++ b/R/facet.R
@@ -424,7 +424,7 @@ draw_facet_window = function(grid, ...) {
                   xg = pretty(as.Date(round(extendrange(xlim)), tz = tz))
                 }
               }
-              abline(v = xg, col = "lightgray", lty = "dotted", lwd = par("lwd"))
+              abline(v = xg, col = .tpar[["grid.col"]], lty = .tpar[["grid.lty"]], lwd = .tpar[["grid.lwd"]])
               gnx = NA
             }
             if (!any(c(par("ylog"), type == "boxplot"))) {
@@ -439,10 +439,10 @@ draw_facet_window = function(grid, ...) {
                   yg = pretty(as.Date(extendrange(ylim), tz = tz))
                 }
               }
-              abline(h = yg, col = "lightgray", lty = "dotted", lwd = par("lwd"))
+              abline(h = yg, col = .tpar[["grid.col"]], lty = .tpar[["grid.lty"]], lwd = .tpar[["grid.lwd"]])
               gny = NA
             }
-            grid(nx = gnx, ny = gny)
+            grid(nx = gnx, ny = gny, col = .tpar[["grid.col"]], lty = .tpar[["grid.lty"]], lwd = .tpar[["grid.lwd"]])
           }
         } else {
           grid

--- a/R/tpar.R
+++ b/R/tpar.R
@@ -78,6 +78,15 @@
 #'   `grid` \tab\tab Logical indicating whether a background panel grid should be added to plots automatically. Defaults to NULL, which is equivalent to `FALSE`.\cr
 #'   \tab\tab\cr
 #'   \tab\tab\cr
+#'   `grid.col` \tab\tab Character or (integer) numeric that specifies the color of the panel grid lines. Defaults to `"lightgray"`.\cr
+#'   \tab\tab\cr
+#'   \tab\tab\cr
+#'   `grid.lty` \tab\tab Character or (integer) numeric that specifies the line type of the panel grid lines. Defaults to `"dotted"`.\cr
+#'   \tab\tab\cr
+#'   \tab\tab\cr
+#'   `grid.lwd` \tab\tab Non-negative numeric giving the line of the panel grid lines. Defaults to `1`.\cr
+#'   \tab\tab\cr
+#'   \tab\tab\cr
 #'   `lmar` \tab\tab A numeric vector of form `c(inner, outer)` that gives the margin padding, in terms of lines, around the automatic `tinyplot` legend. Defaults to `c(1.0, 0.1)`, where the first number represents the "inner" margin between the legend and the plot region, and the second number represents the "outer" margin between the legend and edge of the graphics device. (Note that an exception for the definition of the "outer" legend margin occurs when the legend placement is `"top!"`, since the legend is placed above the plot region but below the main title. In such cases, the outer margin is relative to the existing gap between the title and the plot region, which is itself determined by `par("mar")[3]`.)\cr
 #'   \tab\tab\cr
 #'   \tab\tab\cr
@@ -212,6 +221,23 @@ tpar = function(...) {
     if(!is.null(grid) && !is.logical(grid)) stop("grid needs to be NULL or logical")
     .tpar$grid = grid
   }
+  
+  if (length(opts$grid.col)) {
+    grid.col = opts$grid.col
+    .tpar$grid.col = grid.col
+  }
+  
+  if (length(opts$grid.lty)) {
+    grid.lty = opts$grid.lty
+    .tpar$grid.lty = grid.lty
+  }
+  
+  if (length(opts$grid.lwd)) {
+    grid.lwd = as.numeric(opts$grid.lwd)
+    if(!is.numeric(grid.lwd) || grid.lwd < 0) stop("grid.lwd needs to be a non-negative numeric")
+    .tpar$grid.lwd = grid.lwd
+  }
+  
   
   if (length(opts$lmar)) {
     lmar = as.numeric(opts$lmar)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,6 +29,9 @@
   
   # Plot grid
   .tpar$grid = if(is.null(getOption("tinyplot_grid"))) FALSE else as.logical(getOption("tinyplot_grid"))
+  .tpar$grid.col = if(is.null(getOption("tinyplot_grid.col"))) "lightgray" else getOption("tinyplot_grid.col")
+  .tpar$grid.lty = if(is.null(getOption("tinyplot_grid.lty"))) "dotted" else getOption("tinyplot_grid.lty")
+  .tpar$grid.lwd = if(is.null(getOption("tinyplot_grid.lwd"))) 1 else as.numeric(getOption("tinyplot_grid.lwd"))
   
   # Legend margin, i.e. gap between the legend and the plot elements
   .tpar$lmar = if(is.null(getOption("tinyplot_lmar"))) c(1.0, 0.1) else as.numeric(getOption("tinyplot_lmar"))

--- a/inst/tinytest/_tinysnapshot/tpar_grid.svg
+++ b/inst/tinytest/_tinysnapshot/tpar_grid.svg
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='29.36px' lengthAdjust='spacingAndGlyphs'>Index</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>0:10</text>
+<line x1='112.80' y1='430.56' x2='420.00' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='112.80' y1='430.56' x2='112.80' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='189.60' y1='430.56' x2='189.60' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='266.40' y1='430.56' x2='266.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='343.20' y1='430.56' x2='343.20' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='420.00' y1='430.56' x2='420.00' y2='437.76' style='stroke-width: 0.75;' />
+<text x='112.80' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='189.60' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='266.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='343.20' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='420.00' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
+<line x1='59.04' y1='416.80' x2='59.04' y2='72.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='416.80' x2='51.84' y2='416.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='348.00' x2='51.84' y2='348.00' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='279.20' x2='51.84' y2='279.20' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='210.40' x2='51.84' y2='210.40' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='141.60' x2='51.84' y2='141.60' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='72.80' x2='51.84' y2='72.80' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,416.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(41.76,348.00) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text transform='translate(41.76,279.20) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text transform='translate(41.76,210.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text transform='translate(41.76,141.60) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text transform='translate(41.76,72.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<line x1='36.00' y1='430.56' x2='36.00' y2='59.04' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='112.80' y1='430.56' x2='112.80' y2='59.04' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='189.60' y1='430.56' x2='189.60' y2='59.04' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='266.40' y1='430.56' x2='266.40' y2='59.04' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='343.20' y1='430.56' x2='343.20' y2='59.04' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='420.00' y1='430.56' x2='420.00' y2='59.04' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='496.80' y1='430.56' x2='496.80' y2='59.04' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='59.04' y1='416.80' x2='473.76' y2='416.80' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='59.04' y1='348.00' x2='473.76' y2='348.00' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='59.04' y1='279.20' x2='473.76' y2='279.20' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='59.04' y1='210.40' x2='473.76' y2='210.40' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='59.04' y1='141.60' x2='473.76' y2='141.60' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<line x1='59.04' y1='72.80' x2='473.76' y2='72.80' style='stroke-width: 1.50; stroke: #FF69B4;' />
+<circle cx='74.40' cy='416.80' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='112.80' cy='382.40' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='151.20' cy='348.00' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='189.60' cy='313.60' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='228.00' cy='279.20' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='266.40' cy='244.80' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='304.80' cy='210.40' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='343.20' cy='176.00' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='381.60' cy='141.60' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='420.00' cy='107.20' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='458.40' cy='72.80' r='2.70' style='stroke-width: 0.75; fill: #000000;' />
+</g>
+</svg>

--- a/inst/tinytest/test-tpar.R
+++ b/inst/tinytest/test-tpar.R
@@ -1,0 +1,9 @@
+source("helpers.R")
+using("tinysnapshot")
+
+f = function () {
+  op = tpar(grid = TRUE, grid.col = "hotpink", grid.lty = "solid", grid.lwd = 2)
+  tinyplot(0:10, pch = 19)
+  tpar(op)
+}
+expect_snapshot_plot(f, label = "tpar_grid")

--- a/man/tpar.Rd
+++ b/man/tpar.Rd
@@ -88,6 +88,15 @@ you should rather use \code{par()} instead.
 \code{grid} \tab\tab Logical indicating whether a background panel grid should be added to plots automatically. Defaults to NULL, which is equivalent to \code{FALSE}.\cr
 \tab\tab\cr
 \tab\tab\cr
+\code{grid.col} \tab\tab Character or (integer) numeric that specifies the color of the panel grid lines. Defaults to \code{"lightgray"}.\cr
+\tab\tab\cr
+\tab\tab\cr
+\code{grid.lty} \tab\tab Character or (integer) numeric that specifies the line type of the panel grid lines. Defaults to \code{"dotted"}.\cr
+\tab\tab\cr
+\tab\tab\cr
+\code{grid.lwd} \tab\tab Non-negative numeric giving the line of the panel grid lines. Defaults to \code{1}.\cr
+\tab\tab\cr
+\tab\tab\cr
 \code{lmar} \tab\tab A numeric vector of form \code{c(inner, outer)} that gives the margin padding, in terms of lines, around the automatic \code{tinyplot} legend. Defaults to \code{c(1.0, 0.1)}, where the first number represents the "inner" margin between the legend and the plot region, and the second number represents the "outer" margin between the legend and edge of the graphics device. (Note that an exception for the definition of the "outer" legend margin occurs when the legend placement is \code{"top!"}, since the legend is placed above the plot region but below the main title. In such cases, the outer margin is relative to the existing gap between the title and the plot region, which is itself determined by \code{par("mar")[3]}.)\cr
 \tab\tab\cr
 \tab\tab\cr


### PR DESCRIPTION
Closes #235.

``` r
pkgload::load_all(("~/Documents/Projects/tinyplot"))
#> ℹ Loading tinyplot

op = tpar(grid.col = "hotpink", grid.lty = "solid", grid.lwd = 2)
plt(0:10, pch = 19, grid = TRUE)
```

![](https://i.imgur.com/0u5D7SN.png)<!-- -->

``` r

tpar(op) # reset defaults
plt(0:10, pch = 19, grid = TRUE)
```

![](https://i.imgur.com/JMI9DFt.png)<!-- -->

<sup>Created on 2024-10-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>