### PR TITLE
Issue #225 Deprecate ribbon.alpha

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ functional equivalents (here: `type_histogram()`) are where we can customize
 behaviour by passing appropriate arguments. We're sorry to introduce a breaking
 change, but this new approach should ensure that users have better control of
 how their plots behave, and avoids guesswork on our side.
+- `ribbon.alpha` is deprecated in `tinyplot()`. Use the `alpha` argument of the
+`type_ribbon()` function instead: `plt(..., type = type_ribbon(alpha = 0.5))`
 
 New features:
 

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -248,13 +248,6 @@
 #'   longer discussion about the trade-offs involved.
 #' @param subset,na.action,drop.unused.levels arguments passed to `model.frame`
 #'   when extracting the data from `formula` and `data`.
-#' @param ribbon.alpha numeric factor modifying the opacity alpha of any ribbon
-#'   shading; typically in `[0, 1]`. Only used when `type = "ribbon"`, or when
-#'   the `bg` fill argument is specified in a density plot (since filled density
-#'   plots are converted to ribbon plots internally). If an an applicable plot
-#'   type is called but no explicit value is provided, then will default to
-#'   `tpar("ribbon.alpha")` (i.e., probably `0.2` unless this has been
-#'   overridden by the user in their global settings.)
 #' @param add logical. If TRUE, then elements are added to the current plot rather
 #'   than drawing a new plot window. Note that the automatic legend for the
 #'   added elements will be turned off.
@@ -524,7 +517,6 @@ tinyplot.default = function(
     xmax = NULL,
     ymin = NULL,
     ymax = NULL,
-    ribbon.alpha = NULL,
     add = FALSE,
     file = NULL,
     width = NULL,
@@ -540,9 +532,8 @@ tinyplot.default = function(
 
   if (isTRUE(add)) legend = FALSE
   
-  # sanitize arguments
-  ribbon.alpha = sanitize_ribbon.alpha(ribbon.alpha)
 
+  # sanitize arguments
 
   # type factories vs. strings
   type = sanitize_type(type, x, y)
@@ -556,6 +547,9 @@ tinyplot.default = function(
   palette = substitute(palette)
 
   xlabs = ylabs = NULL
+
+  # will be overwritten by some type_data() functions and ignored by others
+  ribbon.alpha = sanitize_ribbon.alpha(NULL)
 
   ## handle defaults of axes, xaxt, yaxt, frame.plot
   ## - convert axes to character if necessary

--- a/R/type_ribbon.R
+++ b/R/type_ribbon.R
@@ -1,5 +1,10 @@
 #' Ribbon and area plot types
 #' 
+#' @param alpha numeric value between 0 and 1 specifying the opacity of ribbon shading
+#'   If no `alpha` value is provided, then will default to `tpar("ribbon.alpha")` 
+#'   (i.e., probably `0.2` unless this has been overridden by the user in their global 
+#'   settings.)
+#'
 #' @description Type constructor functions for producing polygon ribbons, which 
 #' define a `y` interval (usually spanning from `ymin` to `ymax`) for each
 #' `x` value. Area plots are a special case of ribbon plot where `ymin` is
@@ -33,10 +38,10 @@
 #' # Area plots are often used for time series charts
 #' tinyplot(AirPassengers, type = "area")
 #' @export
-type_ribbon = function() {
+type_ribbon = function(alpha = NULL) {
   out = list(
     draw = draw_ribbon(),
-    data = data_ribbon(),
+    data = data_ribbon(ribbon.alpha = alpha),
     name = "ribbon"
   )
   class(out) = "tinyplot_type"
@@ -59,7 +64,8 @@ draw_ribbon = function() {
 }
 
 
-data_ribbon = function() {
+data_ribbon = function(ribbon.alpha = NULL) {
+    ribbon.alpha = sanitize_ribbon.alpha(ribbon.alpha)
     fun = function(datapoints, xlabs, ...) {
         # Convert x to factor if it's not already
         if (is.character(datapoints$x)) {
@@ -102,7 +108,8 @@ data_ribbon = function() {
             ymin = datapoints$ymin,
             ymax = datapoints$ymax,
             xlabs = xlabs,
-            datapoints = datapoints)
+            datapoints = datapoints,
+            ribbon.alpha = ribbon.alpha)
 
         if (length(unique(datapoints$by)) > 1) out[["by"]] = datapoints$by
         if (length(unique(datapoints$facet)) > 1) out[["facet"]] = datapoints$facet

--- a/inst/tinytest/_tinysnapshot/ribbon_alpha50.svg
+++ b/inst/tinytest/_tinysnapshot/ribbon_alpha50.svg
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='9.33px' lengthAdjust='spacingAndGlyphs'>fit</text>
+<line x1='122.22' y1='430.56' x2='416.77' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='122.22' y1='430.56' x2='122.22' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='220.40' y1='430.56' x2='220.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='318.59' y1='430.56' x2='318.59' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='416.77' y1='430.56' x2='416.77' y2='437.76' style='stroke-width: 0.75;' />
+<text x='122.22' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='220.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='318.59' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='416.77' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.04' y1='424.08' x2='59.04' y2='91.86' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='424.08' x2='51.84' y2='424.08' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='357.63' x2='51.84' y2='357.63' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='291.19' x2='51.84' y2='291.19' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='224.74' x2='51.84' y2='224.74' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='158.30' x2='51.84' y2='158.30' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='91.86' x2='51.84' y2='91.86' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,424.08) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text transform='translate(41.76,357.63) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,291.19) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,224.74) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,158.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(41.76,91.86) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<polygon points='74.40,132.21 84.41,138.11 106.02,150.93 115.83,156.81 135.96,168.96 141.85,172.55 153.63,179.79 167.87,188.66 183.09,198.32 197.82,207.89 198.80,208.53 208.13,214.74 235.13,233.41 237.09,234.81 239.06,236.22 241.51,237.99 263.11,253.99 263.60,254.36 263.60,254.36 263.60,254.36 265.57,255.85 271.46,260.36 276.37,264.16 276.37,264.16 292.08,276.51 296.98,280.43 302.88,285.17 303.37,285.57 325.46,303.62 441.32,402.04 450.64,410.09 458.40,416.80 458.40,343.73 450.64,339.22 441.32,333.78 325.46,264.59 303.37,250.68 302.88,250.37 296.98,246.58 292.08,243.40 276.37,233.03 276.37,233.03 271.46,229.72 265.57,225.71 263.60,224.36 263.60,224.36 263.60,224.36 263.11,224.02 241.51,208.77 239.06,206.99 237.09,205.55 235.13,204.12 208.13,183.73 198.80,176.44 197.82,175.66 183.09,163.93 167.87,151.57 153.63,139.84 141.85,130.04 135.96,125.11 115.83,108.14 106.02,99.81 84.41,81.38 74.40,72.80 ' style='stroke-width: 0.75; stroke: none; fill: #000000; fill-opacity: 0.50;' />
+<polyline points='74.40,102.50 84.41,109.75 106.02,125.37 115.83,132.47 135.96,147.03 141.85,151.29 153.63,159.82 167.87,170.11 183.09,181.12 197.82,191.78 198.80,192.49 208.13,199.23 235.13,218.76 237.09,220.18 239.06,221.61 241.51,223.38 263.11,239.01 263.60,239.36 263.60,239.36 263.60,239.36 265.57,240.78 271.46,245.04 276.37,248.59 276.37,248.59 292.08,259.96 296.98,263.51 302.88,267.77 303.37,268.12 325.46,284.10 441.32,367.91 450.64,374.66 458.40,380.27 ' style='stroke-width: 0.75;' />
+</g>
+</svg>

--- a/inst/tinytest/test-ribbon.R
+++ b/inst/tinytest/test-ribbon.R
@@ -41,3 +41,16 @@ f = function() {
   )
 }
 expect_snapshot_plot(f, label = "ribbon_no_yminymax")
+
+
+f = function() {
+  with(
+    mtcars2,
+    tinyplot(
+      x = wt, y = fit,
+      ymin = lwr, ymax = upr,
+      type = type_ribbon(alpha = .5)
+    )
+  )
+}
+expect_snapshot_plot(f, label = "ribbon_alpha50")

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -45,7 +45,6 @@ tinyplot(x, ...)
   xmax = NULL,
   ymin = NULL,
   ymax = NULL,
-  ribbon.alpha = NULL,
   add = FALSE,
   file = NULL,
   width = NULL,
@@ -388,14 +387,6 @@ or interval plot types. Only used when the \code{type} argument is one of
 \code{"rect"} or \code{"segments"} (where all four min-max coordinates are required),
 or \code{"pointrange"}, \code{"errorbar"}, or \code{"ribbon"} (where only \code{ymin} and
 \code{ymax} required alongside \code{x}).}
-
-\item{ribbon.alpha}{numeric factor modifying the opacity alpha of any ribbon
-shading; typically in \verb{[0, 1]}. Only used when \code{type = "ribbon"}, or when
-the \code{bg} fill argument is specified in a density plot (since filled density
-plots are converted to ribbon plots internally). If an an applicable plot
-type is called but no explicit value is provided, then will default to
-\code{tpar("ribbon.alpha")} (i.e., probably \code{0.2} unless this has been
-overridden by the user in their global settings.)}
 
 \item{add}{logical. If TRUE, then elements are added to the current plot rather
 than drawing a new plot window. Note that the automatic legend for the

--- a/man/type_ribbon.Rd
+++ b/man/type_ribbon.Rd
@@ -7,7 +7,13 @@
 \usage{
 type_area()
 
-type_ribbon()
+type_ribbon(alpha = NULL)
+}
+\arguments{
+\item{alpha}{numeric value between 0 and 1 specifying the opacity of ribbon shading
+If no \code{alpha} value is provided, then will default to \code{tpar("ribbon.alpha")}
+(i.e., probably \code{0.2} unless this has been overridden by the user in their global
+settings.)}
 }
 \description{
 Type constructor functions for producing polygon ribbons, which


### PR DESCRIPTION
Test now looks like this:

```r
f = function() {
  with(
    mtcars2,
    tinyplot(
      x = wt, y = fit,
      ymin = lwr, ymax = upr,
      type = type_ribbon(alpha = .5)
    )
  )
}
expect_snapshot_plot(f, label = "ribbon_alpha50")
```