### PR TITLE
assign pt.lwd for type "p" in legend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ Bugs fixes:
 - The `cex` argument should be respected when using `type="bg"`. Thanks to
   @rjknell for report #307 and @vincentarelbundock for the fix.
 
+- The `lwd` argument should be passed down to `pt.lwd` for type "p". Sets proper line weight for the border of pch symbols in legend. Report in #319 and fix in #320 by @kscott-1.
+
 ## 0.3.0
 
 ### New features

--- a/R/draw_legend.R
+++ b/R/draw_legend.R
@@ -176,6 +176,10 @@ draw_legend = function(
     legend_args[["pt.lwd"]] = legend_args[["pt.lwd"]] %||% 0
   }
 
+  if (identical(type, "p")) {
+    legend_args[["pt.lwd"]] = legend_args[["pt.lwd"]] %||% lwd
+  }
+
   if (identical(type, "n") && isFALSE(gradient)) {
     legend_args[["pch"]] = legend_args[["pch"]] %||% par("pch")
   }


### PR DESCRIPTION
Fixes #319. Looking at the issue I posted earlier, it appears that the jitter plot is internally referenced as "p" type. While my knowledge of this codebase is next to nothing, I don't believe there should be unintended consequences of this change because "p" should only include points. The changes allow for the legend to pick up the `lwd` argument in the case that the `pch` used during plotting can be impacted by that value. Happy to hear more if I have misunderstood this :)

``` r
set.seed(0)
x <- rep(c("A", "B", "C"), each = 20)
y <- runif(60)
gp <- sample(c("X", "Y", "Z"), size = 60, replace = TRUE)
df <- data.frame(x, y, gp)

library(tinyplot)
utils::packageVersion("tinyplot")
#> [1] '0.3.0.99'
plt(
  y ~ x | gp,
  data = df,
  pch = 0:2,
  lwd = 4,
  type = type_jitter()
)
```

![](https://i.imgur.com/FJmuwAq.png)<!-- -->