### PR TITLE
Characters variables inherit same default behaviour as factors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@ Bugs fixes:
   in #319 and fix in #320 by @kscott-1.
 - Passing `x` and/or `y` as character variables now triggers the same default
   plot type behaviour as factors, e.g. boxplots. (#323 @grantmcdermott)
+- Scatter plots (`type_points()`/`"p"`) now work even if `x` or `y` is a factor
+  or character variable. (#323 @grantmcdermott)
 
 ## 0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,11 @@ Bugs fixes:
 
 - The `cex` argument should be respected when using `type="bg"`. Thanks to
   @rjknell for report #307 and @vincentarelbundock for the fix.
-
-- The `lwd` argument should be passed down to `pt.lwd` for type "p". Sets proper line weight for the border of pch symbols in legend. Report in #319 and fix in #320 by @kscott-1.
+- The `lwd` argument is now correctly passed down to `pt.lwd` for type `"p"`,
+  which sets proper line weight for the border of pch symbols in legend. Report
+  in #319 and fix in #320 by @kscott-1.
+- Passing `x` and/or `y` as character variables now triggers the same default
+  plot type behaviour as factors, e.g. boxplots. (#323 @grantmcdermott)
 
 ## 0.3.0
 

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -22,10 +22,10 @@ sanitize_type = function(type, x, y, dots) {
   assert_choice(type, types, null.ok = TRUE)
 
   if (is.null(type)) {
-    if (!is.null(x) && is.factor(x) && !is.factor(y)) {
+    if (!is.null(x) && (is.factor(x) || is.character(x)) && !(is.factor(y) || is.character(y))) {
       # enforce boxplot type for y ~ factor(x)
       type = type_boxplot
-    } else if (is.factor(y)) {
+    } else if (is.factor(y) || is.character(y)) {
       # enforce spineplot type for factor(y) ~ x
       type = type_spineplot
     } else {

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -49,6 +49,7 @@ sanitize_type = function(type, x, y, dots) {
     "lines"      = type_lines,
     "lm"         = type_lm,
     "loess"      = type_loess,
+    "p"          = type_points,
     "pointrange" = type_pointrange,
     "points"     = type_points,
     "polygon"    = type_polygon,

--- a/R/type_jitter.R
+++ b/R/type_jitter.R
@@ -27,8 +27,6 @@ data_jitter = function(factor, amount) {
     fun = function(datapoints, ...) {
         x = datapoints$x
         y = datapoints$y
-        if (is.character(x)) x = as.factor(x)
-        if (is.character(y)) y = as.factor(y)
         if (is.factor(x)) {
             xlvls = levels(x)
             xlabs = seq_along(xlvls)

--- a/R/type_points.R
+++ b/R/type_points.R
@@ -23,13 +23,41 @@
 type_points = function() {
   out = list(
     draw = draw_points(),
-    data = NULL,
+    data = data_points(),
     name = "p"
   )
   class(out) = "tinyplot_type"
   return(out)
 }
 
+data_points = function() {
+  fun = function(datapoints, ...) {
+    # catch for factors (we should still be able to "force" plot these with points)
+    if (is.factor(datapoints$x)) {
+      xlvls = levels(datapoints$x)
+      xlabs = seq_along(xlvls)
+      names(xlabs) = xlvls
+      datapoints$x = as.integer(datapoints$x)
+    } else {
+      xlabs = NULL
+    }
+    if (is.factor(datapoints$y)) {
+      ylvls = levels(datapoints$y)
+      ylabs = seq_along(ylvls)
+      names(ylabs) = ylvls
+      datapoints$y = as.integer(datapoints$y)
+    } else {
+      ylabs = NULL
+    }
+    
+    out = list(
+      datapoints = datapoints,
+      xlabs = xlabs,
+      ylabs = ylabs
+    )
+    return(out)
+  }
+}
 
 draw_points = function() {
     fun = function(ix, iy, icol, ibg, ipch, ilwd, cex, ...) {


### PR DESCRIPTION
Closes #321 

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot

set.seed(0)
x <- rep(c("A", "B", "C"), each = 20)
y <- runif(60)
gp <- sample(c("X", "Y", "Z"), size = 60, replace = TRUE)
df <- data.frame(x, y, gp)

plt(
  y ~ x | gp,
  data = df
)
```

![](https://i.imgur.com/oOak8Uk.png)<!-- -->

I also addressed/enabled factor variable support for `type_points()`.

``` r
plt(
  y ~ x | gp, pch = 0:2,
  data = df,
  type = type_points()
)
```

![](https://i.imgur.com/6yDHrr9.png)<!-- -->

Note: the basic `"p"` type isn't working (I think b/c of #322).

``` r
plt(
  y ~ x | gp, pch = 0:2,
  data = df,
  type = "p"
)
#> Error in Summary.factor(structure(c(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, : 'range' not meaningful for factors
```

<sup>Created on 2025-02-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>