### PR TITLE
Manual palette colours

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@ New features:
 - `tinyplot(..., file = "*.pdf")` will now default to using `cairo_pdf()` if
   cairo graphics are supported on the user's machine. This should help to ensure
   better fidelity of (non-standard) fonts in PDFs. (#311 @grantcdermott)
+- The palette argument now accepts a vector or list of manual colours, e.g.
+  `tinyplot(..., palette = c("cyan4", "hotpink, "purple4"))`, or
+  `tinytheme("clean", palette = c("cyan4", "hotpink, "purple4"))` (#325 @grantmcdermott)
 
 Bugs fixes:
 

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -185,6 +185,10 @@
 #'    unnamed arguments will be ignored and the key `n` argument, denoting the
 #'    number of colours, will automatically be spliced in as the number of
 #'    groups.
+#'    - A vector or list of colours, e.g. `c("darkorange", "purple", "cyan4")`.
+#'    If too few colours are provided for a discrete (qualitative) set of
+#'    groups, then the colours will be recycled with a warning. For continuous
+#'    (sequential) groups, a gradient palette will be interpolated. 
 #' @param legend one of the following options:
 #'    - NULL (default), in which case the legend will be determined by the
 #'    grouping variable. If there is no group variable (i.e., `by` is NULL) then

--- a/inst/tinytest/_tinysnapshot/palette_manual.svg
+++ b/inst/tinytest/_tinysnapshot/palette_manual.svg
@@ -1,0 +1,233 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='432.30,240.30 437.70,240.30 437.70,234.90 432.30,234.90 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<circle cx='435.00' cy='252.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<polygon points='435.00,262.20 438.64,268.50 431.37,268.50 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<text x='463.38' y='223.20' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.70px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text x='445.80' y='241.73' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='35.37px' lengthAdjust='spacingAndGlyphs'>setosa</text>
+<text x='445.80' y='256.13' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
+<text x='445.80' y='270.53' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.02px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MDkuODB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='409.80' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MDkuODB8MC4wMHw1MDQuMDA=)'>
+<text x='234.42' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.39px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.73px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='72.03' y1='430.56' x2='402.32' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='72.03' y1='430.56' x2='72.03' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='127.08' y1='430.56' x2='127.08' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='182.13' y1='430.56' x2='182.13' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='237.17' y1='430.56' x2='237.17' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='292.22' y1='430.56' x2='292.22' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='347.27' y1='430.56' x2='347.27' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='402.32' y1='430.56' x2='402.32' y2='437.76' style='stroke-width: 0.75;' />
+<text x='72.03' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='127.08' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='182.13' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='237.17' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='292.22' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='347.27' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='402.32' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='59.04' y1='397.69' x2='59.04' y2='63.24' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='397.69' x2='51.84' y2='397.69' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='349.91' x2='51.84' y2='349.91' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='302.13' x2='51.84' y2='302.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='254.36' x2='51.84' y2='254.36' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='206.58' x2='51.84' y2='206.58' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='158.80' x2='51.84' y2='158.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='111.02' x2='51.84' y2='111.02' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='63.24' x2='51.84' y2='63.24' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,397.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text transform='translate(41.76,349.91) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text transform='translate(41.76,302.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text transform='translate(41.76,254.36) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text transform='translate(41.76,206.58) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text transform='translate(41.76,158.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text transform='translate(41.76,111.02) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text transform='translate(41.76,63.24) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='59.04,430.56 409.80,430.56 409.80,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDA5LjgwfDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='350.76' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDA5LjgwfDU5LjA0fDQzMC41Ng==)'>
+<polygon points='91.35,343.06 96.75,343.06 96.75,337.66 91.35,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,362.17 96.75,362.17 96.75,356.77 91.35,356.77 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='85.85,381.28 91.25,381.28 91.25,375.88 85.85,375.88 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,390.83 102.25,390.83 102.25,385.43 96.85,385.43 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,352.61 96.75,352.61 96.75,347.21 91.35,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='107.86,314.39 113.26,314.39 113.26,308.99 107.86,308.99 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,390.83 96.75,390.83 96.75,385.43 91.35,385.43 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,352.61 102.25,352.61 102.25,347.21 96.85,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,409.94 96.75,409.94 96.75,404.54 91.35,404.54 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,362.17 102.25,362.17 102.25,356.77 96.85,356.77 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,314.39 102.25,314.39 102.25,308.99 96.85,308.99 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='102.36,371.72 107.76,371.72 107.76,366.32 102.36,366.32 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,371.72 96.75,371.72 96.75,366.32 91.35,366.32 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='74.84,419.50 80.24,419.50 80.24,414.10 74.84,414.10 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='80.34,276.17 85.74,276.17 85.74,270.77 80.34,270.77 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,285.72 102.25,285.72 102.25,280.32 96.85,280.32 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='85.85,314.39 91.25,314.39 91.25,308.99 85.85,308.99 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,343.06 96.75,343.06 96.75,337.66 91.35,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='107.86,285.72 113.26,285.72 113.26,280.32 107.86,280.32 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,343.06 102.25,343.06 102.25,337.66 96.85,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='107.86,314.39 113.26,314.39 113.26,308.99 107.86,308.99 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,343.06 102.25,343.06 102.25,337.66 96.85,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='69.33,390.83 74.73,390.83 74.73,385.43 69.33,385.43 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='107.86,343.06 113.26,343.06 113.26,337.66 107.86,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='118.87,371.72 124.27,371.72 124.27,366.32 118.87,366.32 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='102.36,352.61 107.76,352.61 107.76,347.21 102.36,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='102.36,352.61 107.76,352.61 107.76,347.21 102.36,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,333.50 102.25,333.50 102.25,328.10 96.85,328.10 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,333.50 96.75,333.50 96.75,328.10 91.35,328.10 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='102.36,381.28 107.76,381.28 107.76,375.88 102.36,375.88 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='102.36,371.72 107.76,371.72 107.76,366.32 102.36,366.32 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,314.39 102.25,314.39 102.25,308.99 96.85,308.99 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,333.50 102.25,333.50 102.25,328.10 96.85,328.10 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,304.83 96.75,304.83 96.75,299.43 91.35,299.43 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,362.17 102.25,362.17 102.25,356.77 96.85,356.77 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='80.34,352.61 85.74,352.61 85.74,347.21 80.34,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='85.85,304.83 91.25,304.83 91.25,299.43 85.85,299.43 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,362.17 96.75,362.17 96.75,356.77 91.35,356.77 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='85.85,409.94 91.25,409.94 91.25,404.54 85.85,404.54 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,343.06 102.25,343.06 102.25,337.66 96.85,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='85.85,352.61 91.25,352.61 91.25,347.21 85.85,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='85.85,400.39 91.25,400.39 91.25,394.99 85.85,394.99 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='85.85,409.94 91.25,409.94 91.25,404.54 85.85,404.54 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='102.36,352.61 107.76,352.61 107.76,347.21 102.36,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='118.87,343.06 124.27,343.06 124.27,337.66 118.87,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,371.72 96.75,371.72 96.75,366.32 91.35,366.32 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='102.36,343.06 107.76,343.06 107.76,337.66 102.36,337.66 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,390.83 96.75,390.83 96.75,385.43 91.35,385.43 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='96.85,323.94 102.25,323.94 102.25,318.54 96.85,318.54 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<polygon points='91.35,352.61 96.75,352.61 96.75,347.21 91.35,347.21 ' style='stroke-width: 0.75; stroke: none; fill: #FF8C00; fill-opacity: 0.50;' />
+<circle cx='275.71' cy='158.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='264.70' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='286.72' cy='168.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='237.17' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='270.20' cy='206.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='264.70' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='275.71' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='198.64' cy='359.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='270.20' cy='197.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='231.67' cy='330.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='209.65' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='248.18' cy='263.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='237.17' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='275.71' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='215.15' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='259.19' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='264.70' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='242.68' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='264.70' cy='235.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='231.67' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='281.21' cy='263.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='237.17' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='286.72' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='275.71' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='253.69' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='259.19' cy='197.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='281.21' cy='177.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='292.22' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='264.70' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='209.65' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='226.16' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='220.66' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='231.67' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='297.73' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='264.70' cy='311.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='264.70' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='275.71' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='259.19' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='242.68' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='237.17' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='259.19' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='270.20' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='237.17' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='198.64' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='248.18' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='248.18' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='248.18' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='253.69' cy='235.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='182.13' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<circle cx='242.68' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #A020F0; fill-opacity: 0.50;' />
+<polygon points='347.27,221.49 350.90,227.79 343.63,227.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='297.73,269.27 301.36,275.57 294.09,275.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='341.76,145.05 345.40,151.34 338.13,151.34 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='325.25,221.49 328.89,227.79 321.61,227.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='336.26,202.38 339.90,208.68 332.62,208.68 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='380.30,97.27 383.93,103.57 376.66,103.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='264.70,355.27 268.33,361.57 261.06,361.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='363.78,125.93 367.42,132.23 360.15,132.23 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='336.26,183.27 339.90,189.57 332.62,189.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='352.77,135.49 356.41,141.79 349.14,141.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='297.73,202.38 301.36,208.68 294.09,208.68 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='308.74,211.93 312.37,218.23 305.10,218.23 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='319.74,173.71 323.38,180.01 316.11,180.01 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='292.22,278.82 295.86,285.12 288.58,285.12 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='297.73,269.27 301.36,275.57 294.09,275.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='308.74,211.93 312.37,218.23 305.10,218.23 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='319.74,202.38 323.38,208.68 316.11,208.68 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='385.80,87.71 389.44,94.01 382.17,94.01 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='396.81,87.71 400.45,94.01 393.17,94.01 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='292.22,250.16 295.86,256.45 288.58,256.45 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='330.75,164.16 334.39,170.45 327.12,170.45 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='286.72,288.38 290.35,294.68 283.08,294.68 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='385.80,87.71 389.44,94.01 382.17,94.01 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='286.72,221.49 290.35,227.79 283.08,227.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='330.75,183.27 334.39,189.57 327.12,189.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='347.27,135.49 350.90,141.79 343.63,141.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='281.21,231.05 284.85,237.34 277.58,237.34 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='286.72,240.60 290.35,246.90 283.08,246.90 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='325.25,211.93 328.89,218.23 321.61,218.23 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='336.26,135.49 339.90,141.79 332.62,141.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='352.77,116.38 356.41,122.68 349.14,122.68 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='369.29,68.60 372.92,74.90 365.65,74.90 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='325.25,211.93 328.89,218.23 321.61,218.23 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='297.73,221.49 301.36,227.79 294.09,227.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='325.25,240.60 328.89,246.90 321.61,246.90 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='352.77,87.71 356.41,94.01 349.14,94.01 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='325.25,221.49 328.89,227.79 321.61,227.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='319.74,211.93 323.38,218.23 316.11,218.23 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='281.21,250.16 284.85,256.45 277.58,256.45 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='314.24,164.16 317.88,170.45 310.60,170.45 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='325.25,183.27 328.89,189.57 321.61,189.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='297.73,164.16 301.36,170.45 294.09,170.45 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='297.73,269.27 301.36,275.57 294.09,275.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='341.76,173.71 345.40,180.01 338.13,180.01 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='330.75,183.27 334.39,189.57 327.12,189.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='303.23,183.27 306.87,189.57 299.59,189.57 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='292.22,221.49 295.86,227.79 288.58,227.79 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='303.23,202.38 306.87,208.68 299.59,208.68 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='314.24,231.05 317.88,237.34 310.60,237.34 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+<polygon points='297.73,259.71 301.36,266.01 294.09,266.01 ' style='stroke-width: 0.75; stroke: none; fill: #008B8B; fill-opacity: 0.50;' />
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/palette_manual_continuous.svg
+++ b/inst/tinytest/_tinysnapshot/palette_manual_continuous.svg
@@ -1,0 +1,238 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<image width='18.00' height='86.40' x='435.34' y='205.84' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAABkCAYAAABHLFpgAAAAOklEQVQYlb1RQQoAIAxSv78/z05dYoMi2E1RFBGIsJiEZEL0RgdtBeWdrxSK3rmA1OPUdvRwwM9bFhZOGGZ2QhqjBwAAAABJRU5ErkJggg=='/>
+<text x='453.34' y='296.37' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'> 2.0</text>
+<text x='453.34' y='278.04' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'> 2.5</text>
+<text x='453.34' y='260.59' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'> 3.0</text>
+<text x='453.34' y='242.26' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'> 3.5</text>
+<text x='453.34' y='224.81' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='20.02px' lengthAdjust='spacingAndGlyphs'> 4.0</text>
+<text x='453.34' y='296.37' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='453.34' y='278.04' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='453.34' y='260.59' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='453.34' y='242.26' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='453.34' y='224.81' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.99px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='435.34' y='191.44' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>Sepal.Width</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MTguMDZ8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='418.06' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MTguMDZ8MC4wMHw1MDQuMDA=)'>
+<text x='238.55' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.39px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.73px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='72.34' y1='430.56' x2='410.40' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='72.34' y1='430.56' x2='72.34' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='128.68' y1='430.56' x2='128.68' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='185.02' y1='430.56' x2='185.02' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='241.37' y1='430.56' x2='241.37' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='297.71' y1='430.56' x2='297.71' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='354.05' y1='430.56' x2='354.05' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='410.40' y1='430.56' x2='410.40' y2='437.76' style='stroke-width: 0.75;' />
+<text x='72.34' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='128.68' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='185.02' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='241.37' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='297.71' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='354.05' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='410.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='59.04' y1='397.69' x2='59.04' y2='63.24' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='397.69' x2='51.84' y2='397.69' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='349.91' x2='51.84' y2='349.91' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='302.13' x2='51.84' y2='302.13' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='254.36' x2='51.84' y2='254.36' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='206.58' x2='51.84' y2='206.58' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='158.80' x2='51.84' y2='158.80' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='111.02' x2='51.84' y2='111.02' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='63.24' x2='51.84' y2='63.24' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,397.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text transform='translate(41.76,349.91) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text transform='translate(41.76,302.13) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text transform='translate(41.76,254.36) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text transform='translate(41.76,206.58) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text transform='translate(41.76,158.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text transform='translate(41.76,111.02) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text transform='translate(41.76,63.24) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='59.04,430.56 418.06,430.56 418.06,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDE4LjA2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='359.02' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDE4LjA2fDU5LjA0fDQzMC41Ng==)'>
+<circle cx='94.87' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #3B63B0;' />
+<circle cx='94.87' cy='359.47' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='89.24' cy='378.58' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='100.51' cy='388.13' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='94.87' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #3567AC;' />
+<circle cx='111.78' cy='311.69' r='2.70' style='stroke-width: 0.75; stroke: #2174A0;' />
+<circle cx='94.87' cy='388.13' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='100.51' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='94.87' cy='407.24' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='100.51' cy='359.47' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='100.51' cy='311.69' r='2.70' style='stroke-width: 0.75; stroke: #2E6BA8;' />
+<circle cx='106.14' cy='369.02' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='94.87' cy='369.02' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='77.97' cy='416.80' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='83.61' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: #1B789C;' />
+<circle cx='100.51' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #008B8B;' />
+<circle cx='89.24' cy='311.69' r='2.70' style='stroke-width: 0.75; stroke: #2174A0;' />
+<circle cx='94.87' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #3B63B0;' />
+<circle cx='111.78' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #286FA4;' />
+<circle cx='100.51' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #286FA4;' />
+<circle cx='111.78' cy='311.69' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='100.51' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #2E6BA8;' />
+<circle cx='72.34' cy='388.13' r='2.70' style='stroke-width: 0.75; stroke: #3567AC;' />
+<circle cx='111.78' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #485AB8;' />
+<circle cx='123.05' cy='369.02' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='106.14' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='106.14' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='100.51' cy='330.80' r='2.70' style='stroke-width: 0.75; stroke: #3B63B0;' />
+<circle cx='94.87' cy='330.80' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='106.14' cy='378.58' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='106.14' cy='369.02' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='100.51' cy='311.69' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='100.51' cy='330.80' r='2.70' style='stroke-width: 0.75; stroke: #137E97;' />
+<circle cx='94.87' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: #0C8293;' />
+<circle cx='100.51' cy='359.47' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='83.61' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='89.24' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: #3B63B0;' />
+<circle cx='94.87' cy='359.47' r='2.70' style='stroke-width: 0.75; stroke: #3567AC;' />
+<circle cx='89.24' cy='407.24' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='100.51' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='89.24' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #3B63B0;' />
+<circle cx='89.24' cy='397.69' r='2.70' style='stroke-width: 0.75; stroke: #8C2CE3;' />
+<circle cx='89.24' cy='407.24' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='106.14' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #3B63B0;' />
+<circle cx='123.05' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #286FA4;' />
+<circle cx='94.87' cy='369.02' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='106.14' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #286FA4;' />
+<circle cx='94.87' cy='388.13' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='100.51' cy='321.24' r='2.70' style='stroke-width: 0.75; stroke: #2E6BA8;' />
+<circle cx='94.87' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #485AB8;' />
+<circle cx='280.81' cy='158.80' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='269.54' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='292.08' cy='168.36' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='241.37' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: #8C2CE3;' />
+<circle cx='275.17' cy='206.58' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='269.54' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='280.81' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #485AB8;' />
+<circle cx='201.93' cy='359.47' r='2.70' style='stroke-width: 0.75; stroke: #8631DF;' />
+<circle cx='275.17' cy='197.02' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='235.73' cy='330.80' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='213.20' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #A020F0;' />
+<circle cx='252.64' cy='263.91' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='241.37' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: #9328E7;' />
+<circle cx='280.81' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='218.83' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='263.90' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='269.54' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='247.00' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='269.54' cy='235.24' r='2.70' style='stroke-width: 0.75; stroke: #9328E7;' />
+<circle cx='235.73' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='286.44' cy='263.91' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='241.37' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='292.08' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='280.81' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='258.27' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='263.90' cy='197.02' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='286.44' cy='177.91' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='297.71' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='269.54' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='213.20' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #773BD6;' />
+<circle cx='230.10' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: #8631DF;' />
+<circle cx='224.46' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: #8631DF;' />
+<circle cx='235.73' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='303.35' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='269.54' cy='311.69' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='269.54' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='280.81' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='263.90' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #8C2CE3;' />
+<circle cx='247.00' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='241.37' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='263.90' cy='302.13' r='2.70' style='stroke-width: 0.75; stroke: #773BD6;' />
+<circle cx='275.17' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='241.37' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: #773BD6;' />
+<circle cx='201.93' cy='349.91' r='2.70' style='stroke-width: 0.75; stroke: #8C2CE3;' />
+<circle cx='252.64' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='252.64' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='252.64' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='258.27' cy='235.24' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='185.02' cy='340.36' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='247.00' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='354.05' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #485AB8;' />
+<circle cx='303.35' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='348.42' cy='149.24' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='331.52' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='342.79' cy='206.58' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='387.86' cy='101.47' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='269.54' cy='359.47' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='370.96' cy='130.13' r='2.70' style='stroke-width: 0.75; stroke: #6447CA;' />
+<circle cx='342.79' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='359.69' cy='139.69' r='2.70' style='stroke-width: 0.75; stroke: #3567AC;' />
+<circle cx='303.35' cy='206.58' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='314.61' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='325.88' cy='177.91' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='297.71' cy='283.02' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='303.35' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='314.61' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='325.88' cy='206.58' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='393.50' cy='91.91' r='2.70' style='stroke-width: 0.75; stroke: #286FA4;' />
+<circle cx='404.76' cy='91.91' r='2.70' style='stroke-width: 0.75; stroke: #773BD6;' />
+<circle cx='297.71' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: #9328E7;' />
+<circle cx='337.15' cy='168.36' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='292.08' cy='292.58' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='393.50' cy='91.91' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='292.08' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='337.15' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #485AB8;' />
+<circle cx='354.05' cy='139.69' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='286.44' cy='235.24' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='292.08' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='331.52' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='342.79' cy='139.69' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='359.69' cy='120.58' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='376.59' cy='72.80' r='2.70' style='stroke-width: 0.75; stroke: #286FA4;' />
+<circle cx='331.52' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='303.35' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #6A43CE;' />
+<circle cx='331.52' cy='244.80' r='2.70' style='stroke-width: 0.75; stroke: #773BD6;' />
+<circle cx='359.69' cy='91.91' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='331.52' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='325.88' cy='216.13' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='286.44' cy='254.36' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='320.25' cy='168.36' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='331.52' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='303.35' cy='168.36' r='2.70' style='stroke-width: 0.75; stroke: #5750C2;' />
+<circle cx='303.35' cy='273.47' r='2.70' style='stroke-width: 0.75; stroke: #713FD2;' />
+<circle cx='348.42' cy='177.91' r='2.70' style='stroke-width: 0.75; stroke: #5054BE;' />
+<circle cx='337.15' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #485AB8;' />
+<circle cx='308.98' cy='187.47' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='297.71' cy='225.69' r='2.70' style='stroke-width: 0.75; stroke: #7E36DA;' />
+<circle cx='308.98' cy='206.58' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+<circle cx='320.25' cy='235.24' r='2.70' style='stroke-width: 0.75; stroke: #425EB4;' />
+<circle cx='303.35' cy='263.91' r='2.70' style='stroke-width: 0.75; stroke: #5D4CC6;' />
+</g>
+</svg>

--- a/inst/tinytest/test-palette.R
+++ b/inst/tinytest/test-palette.R
@@ -71,3 +71,37 @@ f = function() {
     )
 }
 expect_snapshot_plot(f, label = "palette_function")
+
+# Test manual colours
+f = function() {
+    op = par(pch = 15)
+    tinyplot(
+        Sepal.Length ~ Petal.Length | Species, iris,
+        pch = "by",
+        alpha = 0.5,
+        palette = c("darkorange", "purple", "cyan4")
+    )
+    par(op)
+}
+expect_snapshot_plot(f, label = "palette_manual")
+
+f = function() {
+    op = par(pch = 15)
+    tinyplot(
+        Sepal.Length ~ Petal.Length | Species, iris,
+        pch = "by",
+        alpha = 0.5,
+        palette = c("darkorange", "purple")
+    )
+    par(op)
+}
+expect_warning(f())
+
+f = function() {
+    tinyplot(
+        Sepal.Length ~ Petal.Length | Sepal.Width, iris,
+        pch = "by",
+        palette =  c("darkcyan", "purple")
+    )
+}
+expect_snapshot_plot(f, label = "palette_manual_continuous")

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -297,6 +297,10 @@ case-insensitive (e.g., "Okabe-Ito" and "okabe-ito" are both valid).
 unnamed arguments will be ignored and the key \code{n} argument, denoting the
 number of colours, will automatically be spliced in as the number of
 groups.
+\item A vector or list of colours, e.g. \code{c("darkorange", "purple", "cyan4")}.
+If too few colours are provided for a discrete (qualitative) set of
+groups, then the colours will be recycled with a warning. For continuous
+(sequential) groups, a gradient palette will be interpolated.
 }}
 
 \item{legend}{one of the following options:

--- a/tinyplot.Rproj
+++ b/tinyplot.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 19acdaca-1dc3-4cd2-a79b-409223de3950
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Fixes #324 

``` r
library(tinyplot)
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot
library(palmerpenguins)

tinytheme("clean2", palette.qualitative = c("darkorange", "purple", "cyan4"))

plt(
  bill_depth_mm ~ bill_length_mm | species, penguins,
  pch = "by",
  alpha = 0.8
)
```

![](https://i.imgur.com/59WEiTU.png)<!-- -->

``` r
tinytheme("clean2")
plt(
  bill_depth_mm ~ bill_length_mm | species, penguins,
  pch = "by",
  alpha = 0.8,
  palette = c("darkorange", "purple", "cyan4")
)
```

![](https://i.imgur.com/59WEiTU.png)<!-- -->

Colors are recycled with a warning if too few are provided.

``` r
plt(
  bill_depth_mm ~ bill_length_mm | species, penguins,
  pch = "by",
  alpha = 0.8,
  palette = c("darkorange", "purple")
)
#> Warning in by_col(ngrps = ngrps, col = col, palette = palette, gradient = by_continuous, : 
#> Fewer colours (2) provided than than there are groups (3). Recycling to make up the shortfall.
```

![](https://i.imgur.com/FoiNYXO.png)<!-- -->

Gradient colors are interpolated.

``` r
plt(
  bill_depth_mm ~ bill_length_mm | body_mass_g, penguins,
  pch = "by",
  alpha = 0.8,
  palette = c("darkcyan", "white", "purple")
)
```

![](https://i.imgur.com/97XbLvk.png)<!-- -->

<sup>Created on 2025-02-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>