### PR TITLE
Switch nested drawing loop: First facets, then by groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,15 @@ Bugs fixes:
   or character variable. (#323 @grantmcdermott)
 - The `col` argument now accepts a numeric index. (#330 @grantmcdermott)
 
+Internals:
+
+- The order of the nested loop for drawing interior plot elements has been
+  switched. We now loop over facets first (outer loop) before looping over
+  groups second (inner loop), rather than vice versa. The old/inverted nesting
+  logic was mostly an artifact of development inertia and this new nesting logic
+  should simplify the creation of certain plot types. (#331 @grantmcdermott)
+
+
 Misc:
 - Improved column spacing of Arguments in the References section of the website.
   (#328 thanks to @etiennebacher's upstream `altdoc` fix)

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -853,7 +853,7 @@ tinyplot.default = function(
   }
 
   # aesthetics by group: col, bg, etc.
-  ngrps = if (is.null(by)) 1L else if (is.factor(by)) length(levels(by)) else if (by_continuous) 100L else length(unique(by)) ## FIXME
+  ngrps = if (is.null(by)) 1L else if (is.factor(by)) length(levels(by)) else if (by_continuous) 100L else length(unique(by))
   pch = by_pch(ngrps = ngrps, type = type, pch = pch)
   lty = by_lty(ngrps = ngrps, type = type, lty = lty)
   lwd = by_lwd(ngrps = ngrps, type = type, lwd = lwd)
@@ -1139,7 +1139,7 @@ tinyplot.default = function(
     # Split group-level data again to grab any "by" groups
     idata = split_data[[i]]
     iby = idata[["by"]]
-    if (!is.null(by)) { ## check (maybe all(iby==""))
+    if (!is.null(by)) { ## maybe all(iby=="")
       if (isTRUE(by_continuous)) {
         idata[["col"]] = col[round(rescale_num(idata$by, from = range(datapoints$by), to = c(1, 100)))]
         idata[["bg"]] = bg[round(rescale_num(idata$by, from = range(datapoints$by), to = c(1, 100)))]
@@ -1166,7 +1166,6 @@ tinyplot.default = function(
     
     # Set the facet "window" manually
     # See: https://github.com/grantmcdermott/tinyplot/issues/65
-    # if (nfacets > 1) par(mfg = c(1, ii))
     if (nfacets > 1) {
       mfgi = ceiling(i / nfacet_cols)
       mfgj = i %% nfacet_cols

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -845,18 +845,14 @@ tinyplot.default = function(
   if (length(unique(datapoints$facet)) == 1) {
     datapoints[["facet"]] = NULL
   }
-  # if (!(by_continuous || is.null(datapoints$facet))) { ## check
-  if (!is.null(datapoints$facet)) { ## check
-    # split_data = split(datapoints, datapoints$by)
-    # split_data = lapply(split_data, as.list)
+  if (!is.null(datapoints$facet)) {
     split_data = split(datapoints, datapoints$facet)
     split_data = lapply(split_data, as.list)
   } else {
-    split_data = list(as.list(datapoints)) ## CHANGE
+    split_data = list(as.list(datapoints))
   }
 
   # aesthetics by group: col, bg, etc.
-  # ngrps = length(split_data)
   ngrps = if (is.null(by)) 1L else if (is.factor(by)) length(levels(by)) else if (by_continuous) 100L else length(unique(by)) ## FIXME
   pch = by_pch(ngrps = ngrps, type = type, pch = pch)
   lty = by_lty(ngrps = ngrps, type = type, lty = lty)
@@ -931,8 +927,6 @@ tinyplot.default = function(
   if ((is.null(legend) || legend != "none") && isFALSE(add)) {
     if (isFALSE(by_continuous)) {
       if (ngrps > 1) {
-        # lgnd_labs = names(split_data)
-        # lgnd_labs = if (is.factor(by)) levels(by) else unique(by)
         lgnd_labs = if (is.factor(datapoints$by)) levels(datapoints$by) else unique(datapoints$by)
       } else {
         lgnd_labs = ylab
@@ -1144,21 +1138,16 @@ tinyplot.default = function(
   for (i in seq_along(split_data)) {
     # Split group-level data again to grab any "by" groups
     idata = split_data[[i]]
-    # ifacet = idata[["facet"]]
     iby = idata[["by"]]
-    # if (!is.null(ifacet)) {
     if (!is.null(by)) { ## check (maybe all(iby==""))
       if (isTRUE(by_continuous)) {
-        # idata[["col"]] = col[round(rescale_num(by, to = c(1, 100)))]
-        # idata[["bg"]] = bg[round(rescale_num(by, to = c(1, 100)))]
         idata[["col"]] = col[round(rescale_num(idata$by, from = range(datapoints$by), to = c(1, 100)))]
         idata[["bg"]] = bg[round(rescale_num(idata$by, from = range(datapoints$by), to = c(1, 100)))]
-        idata = list(idata) ## test
+        idata = list(idata)
       } else {
         idata = lapply(idata, split, iby)
         idata = do.call(function(...) Map("list", ...), idata)
       }
-      # # idata = lapply(idata, split, ifacet)
     } else {
       idata = list(idata)
       if (isTRUE(by_continuous)) {
@@ -1216,24 +1205,6 @@ tinyplot.default = function(
         ibg = idata[[ii]]$bg
       }
 
-      # # Set the facet "window" manually
-      # # See: https://github.com/grantmcdermott/tinyplot/issues/65
-      # # if (nfacets > 1) par(mfg = c(1, ii))
-      # if (nfacets > 1) {
-      #   mfgi = ceiling(ii / nfacet_cols)
-      #   mfgj = ii %% nfacet_cols
-      #   if (mfgj == 0) mfgj = nfacet_cols
-      #   par(mfg = c(mfgi, mfgj))
-      # 
-      #   # For free facets, we need to reset par(usr) based extent of that
-      #   # particular facet... which we calculated and saved to the .fusr env var
-      #   # (list) back in draw_facet_window()
-      #   if (isTRUE(facet.args[["free"]])) {
-      #     fusr = get(".fusr", envir = get(".tinyplot_env", envir = parent.env(environment())))
-      #     par(usr = fusr[[ii]])
-      #   }
-      # }
-
       # empty plot flag
       empty_plot = FALSE
       if (isTRUE(empty) || isTRUE(type == "n") || ((length(ix) == 0) && !(type %in% c("histogram", "hist", "rect", "segments", "spineplot")))) {
@@ -1280,7 +1251,6 @@ tinyplot.default = function(
           ifacet = i,
           facet_by = facet_by,
           data_facet = idata,
-          # data_by = split_data,
           ngrps = ngrps,
           flip = flip,
           type_info = type_info,

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -845,15 +845,19 @@ tinyplot.default = function(
   if (length(unique(datapoints$facet)) == 1) {
     datapoints[["facet"]] = NULL
   }
-  if (!by_continuous) {
-    split_data = split(datapoints, datapoints$by)
+  # if (!(by_continuous || is.null(datapoints$facet))) { ## check
+  if (!is.null(datapoints$facet)) { ## check
+    # split_data = split(datapoints, datapoints$by)
+    # split_data = lapply(split_data, as.list)
+    split_data = split(datapoints, datapoints$facet)
     split_data = lapply(split_data, as.list)
   } else {
-    split_data = list(as.list(datapoints))
+    split_data = list(as.list(datapoints)) ## CHANGE
   }
 
   # aesthetics by group: col, bg, etc.
-  ngrps = length(split_data)
+  # ngrps = length(split_data)
+  ngrps = if (is.factor(by)) length(levels(by)) else 100L ## FIXME
   pch = by_pch(ngrps = ngrps, type = type, pch = pch)
   lty = by_lty(ngrps = ngrps, type = type, lty = lty)
   lwd = by_lwd(ngrps = ngrps, type = type, lwd = lwd)
@@ -927,7 +931,8 @@ tinyplot.default = function(
   if ((is.null(legend) || legend != "none") && isFALSE(add)) {
     if (isFALSE(by_continuous)) {
       if (ngrps > 1) {
-        lgnd_labs = names(split_data)
+        # lgnd_labs = names(split_data)
+        lgnd_labs = if (is.factor(by)) levels(by) else unique(by)
       } else {
         lgnd_labs = ylab
       }
@@ -1131,21 +1136,28 @@ tinyplot.default = function(
 
   # Finally, we can draw all of the plot elements (points, lines, etc.)
   # We'll do this via a nested loops:
-  #  1) Outer loop over groups
-  #  2) Inner loop over facets
+  #  1) Outer loop over facets
+  #  2) Inner loop over groups
 
-  ## Outer loop over the "by" groups
+  ## Outer loop over the facets
   for (i in seq_along(split_data)) {
-    # Split group-level data again to grab any facets
+    # Split group-level data again to grab any "by" groups
     idata = split_data[[i]]
-    ifacet = idata[["facet"]]
-    if (!is.null(ifacet)) {
+    # ifacet = idata[["facet"]]
+    iby = idata[["by"]]
+    # if (!is.null(ifacet)) {
+    if (!is.null(by)) { ## check (maybe all(iby==""))
       if (isTRUE(by_continuous)) {
-        idata[["col"]] = col[round(rescale_num(by, to = c(1, 100)))]
-        idata[["bg"]] = bg[round(rescale_num(by, to = c(1, 100)))]
+        # idata[["col"]] = col[round(rescale_num(by, to = c(1, 100)))]
+        # idata[["bg"]] = bg[round(rescale_num(by, to = c(1, 100)))]
+        idata[["col"]] = col[round(rescale_num(idata$by, from = range(by), to = c(1, 100)))]
+        idata[["bg"]] = bg[round(rescale_num(idata$by, from = range(by), to = c(1, 100)))]
+        idata = list(idata) ## test
+      } else {
+        idata = lapply(idata, split, iby)
+        idata = do.call(function(...) Map("list", ...), idata)
       }
-      idata = lapply(idata, split, ifacet)
-      idata = do.call(function(...) Map("list", ...), idata)
+      # # idata = lapply(idata, split, ifacet)
     } else {
       idata = list(idata)
       if (isTRUE(by_continuous)) {
@@ -1161,15 +1173,34 @@ tinyplot.default = function(
         }
       }
     }
+    
+    # Set the facet "window" manually
+    # See: https://github.com/grantmcdermott/tinyplot/issues/65
+    # if (nfacets > 1) par(mfg = c(1, ii))
+    if (nfacets > 1) {
+      mfgi = ceiling(i / nfacet_cols)
+      mfgj = i %% nfacet_cols
+      if (mfgj == 0) mfgj = nfacet_cols
+      par(mfg = c(mfgi, mfgj))
 
-    icol = col[i]
-    ibg = bg[i]
-    ipch = pch[i]
-    ilty = lty[i]
-    ilwd = lwd[i]
+      # For free facets, we need to reset par(usr) based extent of that
+      # particular facet... which we calculated and saved to the .fusr env var
+      # (list) back in draw_facet_window()
+      if (isTRUE(facet.args[["free"]])) {
+        fusr = get(".fusr", envir = get(".tinyplot_env", envir = parent.env(environment())))
+        par(usr = fusr[[i]])
+      }
+    }
 
-    ## Inner loop over the "facet" variables
+
+    ## Inner loop over the "by" groupings
     for (ii in seq_along(idata)) {
+      icol = col[ii]
+      ibg = bg[ii]
+      ipch = pch[ii]
+      ilty = lty[ii]
+      ilwd = lwd[ii]
+      
       ix = idata[[ii]][["x"]]
       iy = idata[[ii]][["y"]]
       iz = idata[[ii]][["z"]]
@@ -1184,23 +1215,23 @@ tinyplot.default = function(
         ibg = idata[[ii]]$bg
       }
 
-      # Set the facet "window" manually
-      # See: https://github.com/grantmcdermott/tinyplot/issues/65
-      # if (nfacets > 1) par(mfg = c(1, ii))
-      if (nfacets > 1) {
-        mfgi = ceiling(ii / nfacet_cols)
-        mfgj = ii %% nfacet_cols
-        if (mfgj == 0) mfgj = nfacet_cols
-        par(mfg = c(mfgi, mfgj))
-
-        # For free facets, we need to reset par(usr) based extent of that
-        # particular facet... which we calculated and saved to the .fusr env var
-        # (list) back in draw_facet_window()
-        if (isTRUE(facet.args[["free"]])) {
-          fusr = get(".fusr", envir = get(".tinyplot_env", envir = parent.env(environment())))
-          par(usr = fusr[[ii]])
-        }
-      }
+      # # Set the facet "window" manually
+      # # See: https://github.com/grantmcdermott/tinyplot/issues/65
+      # # if (nfacets > 1) par(mfg = c(1, ii))
+      # if (nfacets > 1) {
+      #   mfgi = ceiling(ii / nfacet_cols)
+      #   mfgj = ii %% nfacet_cols
+      #   if (mfgj == 0) mfgj = nfacet_cols
+      #   par(mfg = c(mfgi, mfgj))
+      # 
+      #   # For free facets, we need to reset par(usr) based extent of that
+      #   # particular facet... which we calculated and saved to the .fusr env var
+      #   # (list) back in draw_facet_window()
+      #   if (isTRUE(facet.args[["free"]])) {
+      #     fusr = get(".fusr", envir = get(".tinyplot_env", envir = parent.env(environment())))
+      #     par(usr = fusr[[ii]])
+      #   }
+      # }
 
       # empty plot flag
       empty_plot = FALSE

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -932,7 +932,8 @@ tinyplot.default = function(
     if (isFALSE(by_continuous)) {
       if (ngrps > 1) {
         # lgnd_labs = names(split_data)
-        lgnd_labs = if (is.factor(by)) levels(by) else unique(by)
+        # lgnd_labs = if (is.factor(by)) levels(by) else unique(by)
+        lgnd_labs = if (is.factor(datapoints$by)) levels(datapoints$by) else unique(datapoints$by)
       } else {
         lgnd_labs = ylab
       }
@@ -1150,8 +1151,8 @@ tinyplot.default = function(
       if (isTRUE(by_continuous)) {
         # idata[["col"]] = col[round(rescale_num(by, to = c(1, 100)))]
         # idata[["bg"]] = bg[round(rescale_num(by, to = c(1, 100)))]
-        idata[["col"]] = col[round(rescale_num(idata$by, from = range(by), to = c(1, 100)))]
-        idata[["bg"]] = bg[round(rescale_num(idata$by, from = range(by), to = c(1, 100)))]
+        idata[["col"]] = col[round(rescale_num(idata$by, from = range(datapoints$by), to = c(1, 100)))]
+        idata[["bg"]] = bg[round(rescale_num(idata$by, from = range(datapoints$by), to = c(1, 100)))]
         idata = list(idata) ## test
       } else {
         idata = lapply(idata, split, iby)

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -857,7 +857,7 @@ tinyplot.default = function(
 
   # aesthetics by group: col, bg, etc.
   # ngrps = length(split_data)
-  ngrps = if (is.factor(by)) length(levels(by)) else 100L ## FIXME
+  ngrps = if (is.null(by)) 1L else if (is.factor(by)) length(levels(by)) else if (by_continuous) 100L else length(unique(by)) ## FIXME
   pch = by_pch(ngrps = ngrps, type = type, pch = pch)
   lty = by_lty(ngrps = ngrps, type = type, lty = lty)
   lwd = by_lwd(ngrps = ngrps, type = type, lwd = lwd)
@@ -1275,11 +1275,12 @@ tinyplot.default = function(
           dots = dots,
           type = type,
           x_by = x_by,
-          iby = i,
-          ifacet = ii,
+          iby = ii,
+          ifacet = i,
           facet_by = facet_by,
           data_facet = idata,
-          data_by = split_data,
+          # data_by = split_data,
+          ngrps = ngrps,
           flip = flip,
           type_info = type_info,
           facet_window_args = facet_window_args)

--- a/R/type_boxplot.R
+++ b/R/type_boxplot.R
@@ -53,28 +53,18 @@ type_boxplot = function(
 
 
 draw_boxplot = function(range, width, varwidth, notch, outline, boxwex, staplewex, outwex) {
-    # fun = function(iby, ix, iy, ipch, ilty, icol, ibg, x_by = FALSE, facet_by = FALSE, data_by, flip, ...) {
     fun = function(iby, ix, iy, ipch, ilty, icol, ibg, x_by = FALSE, facet_by = FALSE, ngrps = 1, flip, ...) {
 
         at_ix = unique(ix)
         if (isTRUE(x_by)) boxwex = boxwex * 2
 
         # Handle multiple groups
-        # if (!is.null(data_by) && isFALSE(x_by) && isFALSE(facet_by) && length(data_by) > 1) {
         if (ngrps > 1 && isFALSE(x_by) && isFALSE(facet_by)) {
             boxwex_orig = boxwex
-            # boxwex = boxwex / length(data_by) - 0.01
             boxwex = boxwex / ngrps - 0.01
-            # at_ix = at_ix + seq(
-            #     -((boxwex_orig - boxwex) / 2),
-            #     ((boxwex_orig - boxwex) / 2),
-            #     # length.out = length(data_by)
-            #     length.out = ngrps
-            # )[iby]
             at_ix = at_ix + seq(
               -((boxwex_orig - boxwex) / 2),
               ((boxwex_orig - boxwex) / 2),
-              # length.out = length(data_by)
               length.out = ngrps
             )[iby]
         }

--- a/R/type_boxplot.R
+++ b/R/type_boxplot.R
@@ -53,19 +53,29 @@ type_boxplot = function(
 
 
 draw_boxplot = function(range, width, varwidth, notch, outline, boxwex, staplewex, outwex) {
-    fun = function(iby, ix, iy, ipch, ilty, icol, ibg, x_by = FALSE, facet_by = FALSE, data_by, flip, ...) {
+    # fun = function(iby, ix, iy, ipch, ilty, icol, ibg, x_by = FALSE, facet_by = FALSE, data_by, flip, ...) {
+    fun = function(iby, ix, iy, ipch, ilty, icol, ibg, x_by = FALSE, facet_by = FALSE, ngrps = 1, flip, ...) {
 
         at_ix = unique(ix)
         if (isTRUE(x_by)) boxwex = boxwex * 2
 
         # Handle multiple groups
-        if (!is.null(data_by) && isFALSE(x_by) && isFALSE(facet_by) && length(data_by) > 1) {
+        # if (!is.null(data_by) && isFALSE(x_by) && isFALSE(facet_by) && length(data_by) > 1) {
+        if (ngrps > 1 && isFALSE(x_by) && isFALSE(facet_by)) {
             boxwex_orig = boxwex
-            boxwex = boxwex / length(data_by) - 0.01
+            # boxwex = boxwex / length(data_by) - 0.01
+            boxwex = boxwex / ngrps - 0.01
+            # at_ix = at_ix + seq(
+            #     -((boxwex_orig - boxwex) / 2),
+            #     ((boxwex_orig - boxwex) / 2),
+            #     # length.out = length(data_by)
+            #     length.out = ngrps
+            # )[iby]
             at_ix = at_ix + seq(
-                -((boxwex_orig - boxwex) / 2),
-                ((boxwex_orig - boxwex) / 2),
-                length.out = length(data_by)
+              -((boxwex_orig - boxwex) / 2),
+              ((boxwex_orig - boxwex) / 2),
+              # length.out = length(data_by)
+              length.out = ngrps
             )[iby]
         }
 

--- a/R/type_spineplot.R
+++ b/R/type_spineplot.R
@@ -126,7 +126,7 @@ data_spineplot = function(off = NULL, breaks = NULL, ylevels = ylevels, xaxlabel
         x_by = identical(datapoints$x, datapoints$by)
         y_by = identical(datapoints$y, datapoints$by)
         # if either x_by or y_by are TRUE, we'll only split by facets and then
-        # use some simpl logic to assign colouring on the backend
+        # use some simple logic to assign colouring on the backend
         if (isTRUE(x_by) || isTRUE(y_by)) {
           datapoints = split(datapoints, list(datapoints$facet))
           datapoints = Filter(function(k) nrow(k) > 0, datapoints)
@@ -211,8 +211,8 @@ data_spineplot = function(off = NULL, breaks = NULL, ylevels = ylevels, xaxlabel
         }
         
         # catch for x_by / y/by
-        if (isTRUE(x_by)) datapoints$by = rep(xaxlabels, each = ny) # each x label extends over ny rows
-        if (isTRUE(y_by)) datapoints$by = rep(yaxlabels, length.out = nrow(datapoints))
+        if (isTRUE(x_by)) datapoints$by = factor(rep(xaxlabels, each = ny)) # each x label extends over ny rows
+        if (isTRUE(y_by)) datapoints$by = factor(rep(yaxlabels, length.out = nrow(datapoints)))
           
         ## grayscale flag
         grayscale = length(unique(datapoints[["by"]])) == 1 && is.null(palette) && is.null(.tpar[["palette.qualitative"]])


### PR DESCRIPTION
_Motivated by various discussions, e.g. https://github.com/grantmcdermott/tinyplot/pull/233#issuecomment-2408778373, https://github.com/grantmcdermott/tinyplot/issues/305#issuecomment-2646688729, and https://github.com/grantmcdermott/tinyplot/pull/314#issuecomment-2661779442._

This PR switches the nested loop that we use for drawing interior plot elements. Specifically, the proposed new nesting logic is:

1. Outer loop over facets
2. Inner loop over groups (i.e., `by` within each facet)

The old nesting logic inverted this relationship&mdash;groups first, then facets&mdash;but this was mostly just an artifact of historical inertia. (I only implemented facet support much later than group support, which was enabled from the get-go.) In addition, the whole datapoints + dedicated types refactoring (#222) has now made it much easier to keep track of the final state of transformed variables (e.g., `by` variables that are created internally as part of the relevant `type_draw` function). All told, looping over facets first seems the most natural way to do things now.

All tests are passing locally for me, but @zeileis and @vincentarelbundock  please take a look if you can. Achim, I should also flag that this will possibly (probably?) break your PR in #314, but hopefully facets first will simplify other parts of `type_barplot()` support. It may be possible to simplify parts of `type_spineplot` and `type_ridge` too, as well as any other types that rely on `tinyAxis` internally, but I didn't look into this in great detail.