### PR TITLE
`type_text()` accepts non-character labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ Bugs fixes:
 - Scatter plots (`type_points()`/`"p"`) now work even if `x` or `y` is a factor
   or character variable. (#323 @grantmcdermott)
 - The `col` argument now accepts a numeric index. (#330 @grantmcdermott)
+- `type_text()` now accepts non-character labels. (#336 @grantmcdermott) 
 
 Internals:
 

--- a/R/type_text.R
+++ b/R/type_text.R
@@ -28,7 +28,6 @@ type_text = function(labels, adj = NULL, pos = NULL, offset = 0.5, vfont = NULL,
 
 data_text = function(labels) {
   fun = function(datapoints, ...) {
-    assert_character(labels, name = "labels")
     if (length(labels) != 1 && length(labels) != nrow(datapoints)) {
       msg <- sprintf("`labels` must be of length 1 or %s.", nrow(datapoints))
       stop(msg, call. = FALSE)


### PR DESCRIPTION
Fixes #334.