### PR TITLE
Support `pch` character literals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,17 +17,21 @@ New features:
 
 Bugs fixes:
 
-- The `cex` argument should be respected when using `type="bg"`. Thanks to
-  @rjknell for report #307 and @vincentarelbundock for the fix.
-- The `lwd` argument is now correctly passed down to `pt.lwd` for type `"p"`,
-  which sets proper line weight for the border of pch symbols in legend. Report
-  in #319 and fix in #320 by @kscott-1.
+- The `tinyplot(..., cex = <cex>)` argument should be respected when using
+  `type = "b"`. Thanks to @rjknell for report #307 and @vincentarelbundock for
+  the fix.
+- The `tinyplot(..., lwd = <lwd>)` argument is now correctly passed down to
+  `pt.lwd` for type `"p"`, which sets proper line weight for the border of `pch`
+  symbols in legend. Report in #319 and fix in #320 by @kscott-1.
 - Passing `x` and/or `y` as character variables now triggers the same default
   plot type behaviour as factors, e.g. boxplots. (#323 @grantmcdermott)
 - Scatter plots (`type_points()`/`"p"`) now work even if `x` or `y` is a factor
   or character variable. (#323 @grantmcdermott)
-- The `col` argument now accepts a numeric index. (#330 @grantmcdermott)
-- `type_text()` now accepts non-character labels. (#336 @grantmcdermott) 
+- The `tinyplot(..., col = <col>)` argument now accepts a numeric index.
+  (#330 @grantmcdermott)
+- `type_text()` now accepts non-character labels. (#336 @grantmcdermott)
+- The `tinyplot(..., pch = <pch>)` argument now accepts a string literals, e.g.
+  `pch = "."`. (#338 @grantmcdermott)
 
 Internals:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@ Bugs fixes:
 - The `tinyplot(..., col = <col>)` argument now accepts a numeric index.
   (#330 @grantmcdermott)
 - `type_text()` now accepts non-character labels. (#336 @grantmcdermott)
-- The `tinyplot(..., pch = <pch>)` argument now accepts a string literals, e.g.
+- The `tinyplot(..., pch = <pch>)` argument now accepts character literals, e.g.
   `pch = "."`. (#338 @grantmcdermott)
 
 Internals:

--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -199,8 +199,9 @@ by_pch = function(ngrps, type, pch = NULL) {
   }
 
   if (!no_pch) {
-    if (!is.atomic(pch) || !is.vector(pch) || !is.numeric(pch) || (length(pch) != 1 && length(pch) != ngrps)) {
-      stop(sprintf("`pch` must be `NULL` or a numeric vector of length 1 or %s.", ngrps), call. = FALSE)
+    if (!is.atomic(pch) || !is.vector(pch) || !(is.numeric(pch) || is.character(pch)) || (length(pch) != 1 && length(pch) != ngrps)) {
+    # if (!is.atomic(pch) || !is.vector(pch) || !is.numeric(pch) || (length(pch) != 1 && length(pch) != ngrps)) {
+      stop(sprintf("`pch` must be `NULL`, or a numeric or character vector of length 1 or %s.", ngrps), call. = FALSE)
     }
 
     if (length(pch) == 1) {


### PR DESCRIPTION
Fixes #337 

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot

xx = rnorm(1e4)

plt(xx, pch = ".", alpha = 0.3)
```

![](https://i.imgur.com/MASuPOt.png)<!-- -->

``` r
plt(mpg ~ wt | factor(am), mtcars, pch = c("X", "O"))
```

![](https://i.imgur.com/cWQoBGV.png)<!-- -->

<sup>Created on 2025-03-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>