### PR TITLE
xaxt processing in type_barplot

### DIFF
--- a/R/type_barplot.R
+++ b/R/type_barplot.R
@@ -57,7 +57,7 @@ type_barplot = function(width = 5/6, beside = FALSE, FUN = NULL, xlevels = NULL,
 
 #' @importFrom stats aggregate
 data_barplot = function(width = 5/6, beside = FALSE, FUN = NULL, xlevels = NULL, drop.zeros = FALSE) {
-    fun = function(datapoints, col, bg, lty, lwd, palette, xlab = NULL, ylab = NULL, xlim = NULL, ylim = ylim, yaxt, axes = TRUE, facet_by, ...) {
+    fun = function(datapoints, col, bg, lty, lwd, palette, xlab = NULL, ylab = NULL, xlim = NULL, ylim = NULL, xaxt = NULL, yaxt = NULL, axes = TRUE, facet_by = NULL, ...) {
 
         ## tabulate/aggregate datapoints
         if (is.null(datapoints$y)) {
@@ -149,7 +149,7 @@ data_barplot = function(width = 5/6, beside = FALSE, FUN = NULL, xlevels = NULL,
           xlabs = xlabs, 
           frame.plot = FALSE,
           xaxs = "r",
-          xaxt = "l",
+          xaxt = if (xaxt == "s") "l" else xaxt,
           yaxs = "i",
           col = col,
           bg = bg


### PR DESCRIPTION
Fixes #344 

Previously `xaxt = "l"` was hard-coded. Now the factory-fresh default `xaxt = "s"` gets mapped to `xaxt = "l"` but all other `xaxt` types are still processed. Implications:

- Users can never set `xaxt = "s"` because it always gets overruled. But this might be tolerable because `"s"` never looks great anyway and they can emulate it by adding `xaxt = "a"` for example.
- If themes set another default axis type such as `"t"` ticks will now be drawn. Currently, we don't have such themes, though.

In short, I think this is better than before but maybe still not ideal.