### PR TITLE
avoid duplication of kernel default arguments

### DIFF
--- a/R/type_violin.R
+++ b/R/type_violin.R
@@ -34,7 +34,7 @@ type_violin = function(
         # more args from density here?
         alpha = NULL
     ) {
-    kernel = match.arg(kernel, c("gaussian", "epanechnikov", "rectangular", "triangular", "biweight", "cosine", "optcosine"))
+    kernel = match.arg(kernel)
     if (is.logical(joint.bw)) {
         joint.bw = ifelse(joint.bw, "mean", "none")
     }


### PR DESCRIPTION
Avoid duplication of kernel default arguments.

From man page of `match.arg`: 
> In the one-argument form match.arg(arg), the choices are obtained from a default setting for the formal argument arg of the function from which match.arg was called.