### PR TITLE
Pass on bg argument in type_lines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,8 @@ where the formatting is also better._
 - `type_text()` now accepts non-character labels. (#336 @grantmcdermott)
 - The `tinyplot(..., pch = <pch>)` argument now accepts character literals, e.g.
   `pch = "."`. (#338 @grantmcdermott)
+- Line plots (`type_lines()`/`"l"`) now pass on the `bg` argument to the
+  drawing function. Thanks to @wviechtb for report #355 (@zeileis).
 
 ### Internals:
 

--- a/R/type_lines.R
+++ b/R/type_lines.R
@@ -24,13 +24,14 @@ type_lines = function(type = "l") {
 
 
 draw_lines = function(type = "l") {
-    fun = function(ix, iy, icol, ipch, ilty, ilwd, cex = 1, ...) {
+    fun = function(ix, iy, icol, ipch, ibg, ilty, ilwd, cex = 1, ...) {
         lines(
             x = ix,
             y = iy,
             col = icol,
             type = type,
             pch = ipch,
+            bg = ibg,
             lty = ilty,
             lwd = ilwd,
             cex = cex

--- a/R/type_ribbon.R
+++ b/R/type_ribbon.R
@@ -58,7 +58,7 @@ draw_ribbon = function() {
         } else {
             polyg(c(ixmin, rev(ixmax)), iy = c(iy, rev(iy)), icol = NA, ibg = ibg)
         }
-        lin(ix = ix, iy = iy, icol = icol, ipch = ipch, ilty = ilty, ilwd = ilwd, type = "l")
+        lin(ix = ix, iy = iy, icol = icol, ipch = ipch, ibg = ibg, ilty = ilty, ilwd = ilwd, type = "l")
     }
     return(fun)
 }


### PR DESCRIPTION
Fixes #355

The `bg`/`fill` argument was not passed on correctly to the `draw_lines()` function in `type_lines()`. Fixed and documented now.