### PR TITLE
Absolute numbers in tinylabel() via abs_ prefix

### DIFF
--- a/R/tinylabel.R
+++ b/R/tinylabel.R
@@ -5,7 +5,7 @@
 #' ultimately get passed to.
 #' @param x a numeric or character vector
 #' @param labeller a formatting function to be applied to `x`, e.g. `abs`,
-#'   `topper`, etc. Can also be one of the following convenience strings, for
+#'   `toupper`, etc. Can also be one of the following convenience strings, for
 #'   which common formatting transformations are provided: `"percent"`,
 #'   `"comma"`, `"dollar"`, `"euro"`, or `"sterling"`.
 #'
@@ -17,9 +17,17 @@ tinylabel = function(x, labeller = NULL) {
 }
 
 
-labeller_fun = function(label = c("percent", "comma", "dollar", "euro", "sterling")) {
-  label = match.arg(label)
-  
+labeller_fun = function(label = "percent") {
+  ## all labels plus absolute value version
+  labels = c("percent", "comma", "dollar", "euro", "sterling")
+  labels = c(labels, paste0("abs_", labels))
+
+  ## match full label first, then store abs_ info separately
+  label = match.arg(label, labels)
+  abs_ = substr(label, 1L, 4L) == "abs_"
+  if (abs_) label = substr(label, 5L, nchar(label))
+
+  ## actual formatting function
   format_percent = function(x) {
     sprintf("%.0f%%", x * 100)
   }
@@ -40,7 +48,7 @@ labeller_fun = function(label = c("percent", "comma", "dollar", "euro", "sterlin
     paste0("\u00a3", prettyNum(x, big.mark = ",", scientific = FALSE))
   }
   
-  switch(
+  fun = switch(
     label,
     percent  = format_percent,
     comma    = format_comma,
@@ -48,4 +56,7 @@ labeller_fun = function(label = c("percent", "comma", "dollar", "euro", "sterlin
     euro     = format_euro,
     sterling = format_sterling
   )
+
+  ## combine with absolute value if necessary
+  if (abs_) function(x) fun(abs(x)) else fun
 }

--- a/R/type_barplot.R
+++ b/R/type_barplot.R
@@ -56,7 +56,7 @@
 #' tinytheme("clean2", palette.qualitative = c("black", "sienna", "indianred", "goldenrod"))
 #' hec = as.data.frame(proportions(HairEyeColor, 2:3))
 #' tinyplot(Freq ~ Eye | Hair, facet = ~ Sex, data = hec, type = "barplot",
-#'   center = TRUE, flip = TRUE, facet.args = list(ncol = 1))
+#'   center = TRUE, flip = TRUE, facet.args = list(ncol = 1), yaxl = "percent")
 #'
 #' tinytheme()
 #' 
@@ -169,7 +169,13 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
         xlabs = 1L:nx
         names(xlabs) = levels(datapoints$x)
         
-        if (!isFALSE(center) && is.null(yaxl)) yaxl = abs 
+        if (!isFALSE(center)) {
+          if (is.null(yaxl)) {
+            yaxl = abs
+          } else if (is.character(yaxl)) {
+            yaxl = paste0("abs_", yaxl)
+          }
+        }
         
         out = list(
           datapoints = datapoints,

--- a/man/tinylabel.Rd
+++ b/man/tinylabel.Rd
@@ -10,7 +10,7 @@ tinylabel(x, labeller = NULL)
 \item{x}{a numeric or character vector}
 
 \item{labeller}{a formatting function to be applied to \code{x}, e.g. \code{abs},
-\code{topper}, etc. Can also be one of the following convenience strings, for
+\code{toupper}, etc. Can also be one of the following convenience strings, for
 which common formatting transformations are provided: \code{"percent"},
 \code{"comma"}, \code{"dollar"}, \code{"euro"}, or \code{"sterling"}.}
 }

--- a/man/type_barplot.Rd
+++ b/man/type_barplot.Rd
@@ -78,7 +78,7 @@ tinyplot(Freq ~ Sex | Survived, facet = ~ Class, data = as.data.frame(Titanic),
 tinytheme("clean2", palette.qualitative = c("black", "sienna", "indianred", "goldenrod"))
 hec = as.data.frame(proportions(HairEyeColor, 2:3))
 tinyplot(Freq ~ Eye | Hair, facet = ~ Sex, data = hec, type = "barplot",
-  center = TRUE, flip = TRUE, facet.args = list(ncol = 1))
+  center = TRUE, flip = TRUE, facet.args = list(ncol = 1), yaxl = "percent")
 
 tinytheme()
 


### PR DESCRIPTION
As discussed in #361 all `tinylabel()` specifications can optionally be used with an `abs_` prefix as well which will internally apply `abs()` before using the actual `format_*()` function.

This is convenient for centered bar plots and illustrated now in the `HairEyeColor` example in `?type_barplot`.