### PR TITLE
`xaxl`/`yaxl` symbol shortcuts

### DIFF
--- a/R/tinylabel.R
+++ b/R/tinylabel.R
@@ -10,6 +10,7 @@
 #'   provided: `"percent"` (`"%"`), `"comma"` (`","`), `"dollar"` (`"$"`),
 #'   `"euro"` (`"€"`), or `"sterling"` (`"£"`).
 #' @examples
+#' \dontrun{
 #' x = 1e4
 #' tinylabel(x, "comma")
 #' tinylabel(x, ",") # same
@@ -24,7 +25,7 @@
 #'   trend = 1:12 + rnorm(12, sd = 1)
 #' )
 #' tinyplot(trend ~ date, data = dat, xaxl = function(x) format(x, "%b, %Y"))
-#' 
+#' }
 #' @keywords internal
 tinylabel = function(x, labeller = NULL) {
   if (is.null(labeller)) return(x)

--- a/R/tinylabel.R
+++ b/R/tinylabel.R
@@ -5,9 +5,10 @@
 #' ultimately get passed to.
 #' @param x a numeric or character vector
 #' @param labeller a formatting function to be applied to `x`, e.g. `abs`,
-#'   `toupper`, etc. Can also be one of the following convenience strings, for
-#'   which common formatting transformations are provided: `"percent"`,
-#'   `"comma"`, `"dollar"`, `"euro"`, or `"sterling"`.
+#'   `toupper`, etc. Can also be one of the following convenience strings
+#'   (symbols), for which common formatting transformations are provided:
+#'   `"percent"` (`"%"`), `"comma"` (`","`), `"dollar"` (`"$"`),
+#'   `"euro"` (`"€"`), or `"sterling"` (`"£"`).
 #'
 #' @keywords internal
 tinylabel = function(x, labeller = NULL) {
@@ -18,8 +19,18 @@ tinylabel = function(x, labeller = NULL) {
 
 
 labeller_fun = function(label = "percent") {
+  
+  labels = c(
+    "%"       = "percent",
+    ","       = "comma",
+    "$"       = "dollar",
+    "\u20ac"  = "euro",
+    "\u00a3"  = "sterling"
+  )
+  if (label %in% names(labels)) label = labels[label]
+  
   ## all labels plus absolute value version
-  labels = c("percent", "comma", "dollar", "euro", "sterling")
+  # labels = c("percent", "comma", "dollar", "euro", "sterling")
   labels = c(labels, paste0("abs_", labels))
 
   ## match full label first, then store abs_ info separately

--- a/R/tinylabel.R
+++ b/R/tinylabel.R
@@ -5,11 +5,26 @@
 #' ultimately get passed to.
 #' @param x a numeric or character vector
 #' @param labeller a formatting function to be applied to `x`, e.g. `abs`,
-#'   `toupper`, etc. Can also be one of the following convenience strings
-#'   (symbols), for which common formatting transformations are provided:
-#'   `"percent"` (`"%"`), `"comma"` (`","`), `"dollar"` (`"$"`),
+#'   `toupper`, `format`, etc. Can also be one of the following convenience
+#'   strings (symbols), for which common formatting transformations are
+#'   provided: `"percent"` (`"%"`), `"comma"` (`","`), `"dollar"` (`"$"`),
 #'   `"euro"` (`"€"`), or `"sterling"` (`"£"`).
-#'
+#' @examples
+#' x = 1e4
+#' tinylabel(x, "comma")
+#' tinylabel(x, ",") # same
+#' tinylabel(x, "$") # or "dollar"
+#' 
+#' # pass to xaxl/yaxl for adjusting axes tick labels in a tinyplot call
+#' tinyplot(I(mpg/hp) ~ hp, data = mtcars, yaxl = "%")
+#' 
+#' # function example (here: date formatting)
+#' dat = data.frame(
+#'   date = seq(as.Date("2000/1/1"), by = "month", length.out = 12),
+#'   trend = 1:12 + rnorm(12, sd = 1)
+#' )
+#' tinyplot(trend ~ date, data = dat, xaxl = function(x) format(x, "%b, %Y"))
+#' 
 #' @keywords internal
 tinylabel = function(x, labeller = NULL) {
   if (is.null(labeller)) return(x)

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -175,8 +175,9 @@
 #' @param xaxl,yaxl A formatting function (or character string) to apply to the
 #'   x- or y-axis tick labels. This affects the _appearance_ of the labels only,
 #'   not the calculation or positioning of the tick marks. In addition to custom
-#'   functions, users can supply one of several convenience strings for common
-#'   formats: `"percent"`, `"comma"`, `"dollar"`, `"euro"`, or `"sterling"`.
+#'   functions, users can supply one of several convenience strings (symbols)
+#'   for common formats: `"percent"` (`"%"`), `"comma"` (`","`), `"dollar"`
+#'   (`"$"`), `"euro"` (`"€"`), or `"sterling"` (`"£"`).
 #' @param log a character string which contains "x" if the x axis is to be
 #'   logarithmic, "y" if the y axis is to be logarithmic and "xy" or "yx" if
 #'   both axes are to be logarithmic.

--- a/man/tinylabel.Rd
+++ b/man/tinylabel.Rd
@@ -10,9 +10,10 @@ tinylabel(x, labeller = NULL)
 \item{x}{a numeric or character vector}
 
 \item{labeller}{a formatting function to be applied to \code{x}, e.g. \code{abs},
-\code{toupper}, etc. Can also be one of the following convenience strings, for
-which common formatting transformations are provided: \code{"percent"},
-\code{"comma"}, \code{"dollar"}, \code{"euro"}, or \code{"sterling"}.}
+\code{toupper}, etc. Can also be one of the following convenience strings
+(symbols), for which common formatting transformations are provided:
+\code{"percent"} (\code{"\%"}), \code{"comma"} (\code{","}), \code{"dollar"} (\code{"$"}),
+\code{"euro"} (\code{"€"}), or \code{"sterling"} (\code{"£"}).}
 }
 \description{
 Internal function for formatting label appearance, e.g. axis

--- a/man/tinylabel.Rd
+++ b/man/tinylabel.Rd
@@ -21,6 +21,7 @@ ticks labels. This is what the top-level \code{xaxl} and \code{yaxl} arguments
 ultimately get passed to.
 }
 \examples{
+\dontrun{
 x = 1e4
 tinylabel(x, "comma")
 tinylabel(x, ",") # same
@@ -35,6 +36,6 @@ dat = data.frame(
   trend = 1:12 + rnorm(12, sd = 1)
 )
 tinyplot(trend ~ date, data = dat, xaxl = function(x) format(x, "\%b, \%Y"))
-
+}
 }
 \keyword{internal}

--- a/man/tinylabel.Rd
+++ b/man/tinylabel.Rd
@@ -10,14 +10,31 @@ tinylabel(x, labeller = NULL)
 \item{x}{a numeric or character vector}
 
 \item{labeller}{a formatting function to be applied to \code{x}, e.g. \code{abs},
-\code{toupper}, etc. Can also be one of the following convenience strings
-(symbols), for which common formatting transformations are provided:
-\code{"percent"} (\code{"\%"}), \code{"comma"} (\code{","}), \code{"dollar"} (\code{"$"}),
+\code{toupper}, \code{format}, etc. Can also be one of the following convenience
+strings (symbols), for which common formatting transformations are
+provided: \code{"percent"} (\code{"\%"}), \code{"comma"} (\code{","}), \code{"dollar"} (\code{"$"}),
 \code{"euro"} (\code{"€"}), or \code{"sterling"} (\code{"£"}).}
 }
 \description{
 Internal function for formatting label appearance, e.g. axis
 ticks labels. This is what the top-level \code{xaxl} and \code{yaxl} arguments
 ultimately get passed to.
+}
+\examples{
+x = 1e4
+tinylabel(x, "comma")
+tinylabel(x, ",") # same
+tinylabel(x, "$") # or "dollar"
+
+# pass to xaxl/yaxl for adjusting axes tick labels in a tinyplot call
+tinyplot(I(mpg/hp) ~ hp, data = mtcars, yaxl = "\%")
+
+# function example (here: date formatting)
+dat = data.frame(
+  date = seq(as.Date("2000/1/1"), by = "month", length.out = 12),
+  trend = 1:12 + rnorm(12, sd = 1)
+)
+tinyplot(trend ~ date, data = dat, xaxl = function(x) format(x, "\%b, \%Y"))
+
 }
 \keyword{internal}

--- a/man/tinyplot.Rd
+++ b/man/tinyplot.Rd
@@ -297,8 +297,9 @@ for the possible values.}
 \item{xaxl, yaxl}{A formatting function (or character string) to apply to the
 x- or y-axis tick labels. This affects the \emph{appearance} of the labels only,
 not the calculation or positioning of the tick marks. In addition to custom
-functions, users can supply one of several convenience strings for common
-formats: \code{"percent"}, \code{"comma"}, \code{"dollar"}, \code{"euro"}, or \code{"sterling"}.}
+functions, users can supply one of several convenience strings (symbols)
+for common formats: \code{"percent"} (\code{"\%"}), \code{"comma"} (\code{","}), \code{"dollar"}
+(\code{"$"}), \code{"euro"} (\code{"€"}), or \code{"sterling"} (\code{"£"}).}
 
 \item{log}{a character string which contains "x" if the x axis is to be
 logarithmic, "y" if the y axis is to be logarithmic and "xy" or "yx" if


### PR DESCRIPTION
This PR would allow users to pass the equivalent symbol as a(n even shorter) shortcut to `xaxl`/`yaxl`.  For example, `"percent"` <=> `"%"`, `"dollar"` <=> `"$"`, etc.

``` r
pkgload::load_all("~/Documents/Projects/tinyplot")
#> ℹ Loading tinyplot
tinytheme('ipsum')

dat = data.frame(
  x = rnorm(100, 1e3, 50),
  y = rnorm(100, 1e3, 10)
)
plt(y ~ x, dat, xaxl = "€", yaxl = "$")
```

![](https://i.imgur.com/zqvudxX.png)<!-- -->

``` r
plt(y ~ I(x/1e4), dat, xaxl = "%", yaxl = ",")
```

![](https://i.imgur.com/SvQxXQ1.png)<!-- -->

``` r
tinytheme()
```

<sup>Created on 2025-04-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Thoughts?