### PR TITLE
Fix factor-based y-tick labels for "p"-alike plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,9 @@ where the formatting is also better._
   i.e. cases where `las = 2` or `las = 3`. (#369 @grantmcdermott)
 - Better integration with the Positron IDE graphics pane. Thanks to @thomasp85
   for the report and helpful suggestions. (#377 @grantmcdermott)
+- Fixed a bug that resulted in y-axis labels being coerced to numeric for
+  `"p"`-alike plot types (including `"jitter"`) if `y` is a factor or character
+  (#387 @grantmcdermott).
 
 ### Internals:
 

--- a/R/facet.R
+++ b/R/facet.R
@@ -270,7 +270,7 @@ draw_facet_window = function(
         lty = get_tpar(c("lty.yaxs", "lty.axis"), 1)
       )
       type_range_x = type %in% c("barplot", "pointrange", "errorbar", "ribbon", "boxplot", "p", "violin") && !is.null(xlabs)
-      type_range_y = isTRUE(flip) && type %in% c("barplot", "pointrange", "errorbar", "ribbon", "boxplot", "p", "violin") && !is.null(ylabs)
+      type_range_y = !is.null(ylabs) && (type == "p" || (isTRUE(flip) && type %in% c("barplot", "pointrange", "errorbar", "ribbon", "boxplot", "violin")))
       if (type_range_x) {
         args_x = modifyList(args_x, list(at = xlabs, labels = names(xlabs)))
       }

--- a/inst/tinytest/_tinysnapshot/type_j_y.svg
+++ b/inst/tinytest/_tinysnapshot/type_j_y.svg
@@ -1,0 +1,201 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<text x='266.40' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.73px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.70px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<line x1='149.82' y1='430.56' x2='468.59' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='149.82' y1='430.56' x2='149.82' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='256.07' y1='430.56' x2='256.07' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='362.33' y1='430.56' x2='362.33' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='468.59' y1='430.56' x2='468.59' y2='437.76' style='stroke-width: 0.75;' />
+<text x='149.82' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='256.07' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='362.33' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='468.59' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text>
+<line x1='59.04' y1='389.59' x2='59.04' y2='100.69' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='389.59' x2='51.84' y2='389.59' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='245.14' x2='51.84' y2='245.14' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='100.69' x2='51.84' y2='100.69' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,389.59) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='35.37px' lengthAdjust='spacingAndGlyphs'>setosa</text>
+<text transform='translate(41.76,245.14) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
+<text transform='translate(41.76,100.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.02px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+<polygon points='59.04,430.56 473.76,430.56 473.76,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='414.72' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDczLjc2fDU5LjA0fDQzMC41Ng==)'>
+<circle cx='162.21' cy='376.91' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='141.05' cy='399.75' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='117.03' cy='373.48' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='108.72' cy='395.69' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='150.42' cy='379.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='192.40' cy='373.65' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='108.32' cy='407.63' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='148.27' cy='416.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='86.73' cy='410.64' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='140.06' cy='379.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='192.14' cy='364.47' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='129.50' cy='386.67' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='130.41' cy='383.71' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='74.40' cy='407.10' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='234.66' cy='387.55' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='226.07' cy='408.11' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='194.35' cy='392.37' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='158.82' cy='400.16' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='224.09' cy='411.77' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='160.70' cy='407.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='194.04' cy='376.32' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='158.91' cy='394.68' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='109.39' cy='394.56' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='162.34' cy='390.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='126.79' cy='393.78' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='149.88' cy='410.59' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='149.35' cy='370.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='172.79' cy='384.26' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='170.84' cy='372.58' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='119.37' cy='374.05' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='129.58' cy='365.43' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='193.64' cy='368.64' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='170.59' cy='400.17' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='203.73' cy='403.50' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='137.08' cy='375.59' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='151.23' cy='375.30' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='200.85' cy='365.44' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='137.95' cy='372.65' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='87.79' cy='410.78' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='160.92' cy='401.85' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='149.31' cy='407.23' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='96.42' cy='373.17' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='84.10' cy='411.03' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='151.83' cy='411.02' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='160.15' cy='414.31' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='130.51' cy='415.41' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='162.09' cy='387.75' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='107.91' cy='411.99' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='183.70' cy='375.54' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='150.32' cy='376.22' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='361.62' cy='222.89' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='297.93' cy='244.15' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='351.27' cy='224.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='204.16' cy='248.44' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='307.24' cy='264.91' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='225.25' cy='248.47' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='288.70' cy='218.11' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='137.80' cy='246.03' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='318.81' cy='259.44' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='171.13' cy='259.02' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='150.56' cy='242.71' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='247.50' cy='236.48' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.18' cy='254.59' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='266.98' cy='270.51' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='215.06' cy='247.95' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='329.13' cy='225.57' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='212.60' cy='240.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='236.22' cy='253.61' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='278.15' cy='242.40' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='212.47' cy='222.45' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='243.51' cy='245.72' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='265.17' cy='264.11' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='286.75' cy='242.65' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='266.61' cy='218.48' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='297.29' cy='255.90' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='320.76' cy='226.62' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='338.99' cy='256.29' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='329.92' cy='263.31' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='256.14' cy='271.24' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='222.08' cy='259.83' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='203.29' cy='253.74' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='201.49' cy='264.84' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='234.22' cy='256.46' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='256.69' cy='273.02' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='193.49' cy='216.45' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='256.34' cy='227.55' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='329.32' cy='269.03' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='286.21' cy='223.76' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='211.81' cy='241.99' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='202.12' cy='249.68' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='203.66' cy='270.12' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='264.58' cy='241.59' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='233.58' cy='269.94' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='151.66' cy='261.82' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='215.38' cy='242.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='225.19' cy='246.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='223.49' cy='264.82' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='277.39' cy='265.39' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='161.48' cy='245.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='224.70' cy='219.68' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='288.49' cy='110.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='233.62' cy='118.69' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='371.75' cy='113.99' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='287.48' cy='98.91' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='311.08' cy='128.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='428.05' cy='83.43' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='140.21' cy='123.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='395.20' cy='98.39' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='330.61' cy='96.57' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='381.47' cy='93.82' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='309.67' cy='88.27' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='300.01' cy='122.45' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='342.15' cy='111.61' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='224.00' cy='74.93' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='234.98' cy='100.69' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='298.74' cy='121.76' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='307.08' cy='79.35' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='436.10' cy='117.73' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='437.19' cy='76.13' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.47' cy='78.34' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='351.10' cy='121.70' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='213.19' cy='84.20' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='437.02' cy='103.39' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='288.33' cy='121.74' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='331.39' cy='78.43' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='383.13' cy='110.12' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='279.11' cy='111.13' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='268.67' cy='106.25' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='297.44' cy='101.90' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='384.54' cy='108.32' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='406.55' cy='102.67' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='458.40' cy='126.70' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='299.14' cy='118.75' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='289.81' cy='72.80' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='268.19' cy='110.61' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='437.05' cy='119.70' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='289.32' cy='101.37' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='296.93' cy='128.50' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='257.20' cy='109.96' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='352.23' cy='127.86' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='328.96' cy='79.47' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='349.92' cy='87.30' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='234.67' cy='111.36' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='342.27' cy='107.25' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='331.45' cy='110.37' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='331.80' cy='124.39' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='286.55' cy='85.84' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='311.09' cy='94.74' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='276.45' cy='121.18' r='2.70' style='stroke-width: 0.75;' />
+<circle cx='243.96' cy='127.70' r='2.70' style='stroke-width: 0.75;' />
+</g>
+</svg>

--- a/inst/tinytest/test-misc.R
+++ b/inst/tinytest/test-misc.R
@@ -23,6 +23,11 @@ f = function() {
 }
 expect_snapshot_plot(f, label = "type_j")
 
+f = function() {
+  set.seed(42)
+  tinyplot(Species ~ Sepal.Length, data = iris, type = "j")
+}
+expect_snapshot_plot(f, label = "type_j_y")
 
 # log axes
 f = function() {


### PR DESCRIPTION
Fixes #386.

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot
tinytheme("bw")

plt(
  species ~ flipper_len, data = penguins,
  type = "p"
)
```

![](https://i.imgur.com/bffXuHR.png)<!-- -->

``` r

plt(
  species ~ flipper_len, data = penguins,
  type = "j"
)
```

![](https://i.imgur.com/5A7X3lt.png)<!-- -->

<sup>Created on 2025-05-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>