### PR TITLE
recordGraphics redux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,10 @@ where the formatting is also better._
 - Fixed dynamic x-axis margin spacing for perpendicular (vertical) label text,
   i.e. cases where `las = 2` or `las = 3`. (#369 @grantmcdermott)
 - Better integration with the Positron IDE graphics pane. Thanks to @thomasp85
-  for the report and helpful suggestions. (#377 @grantmcdermott)
+  for the report and helpful suggestions. (#377, #394 @grantmcdermott)
+  - The one remaining Positron issue at present is calling `plt_add()` on a
+    faceted plot, but this appears to be an upstream limitation/bug (see
+    https://github.com/posit-dev/positron/issues/7316)
 - Fixed a bug that resulted in y-axis labels being coerced to numeric for
   `"p"`-alike plot types (including `"jitter"`) if `y` is a factor or character
   (#387 @grantmcdermott).

--- a/R/draw_legend.R
+++ b/R/draw_legend.R
@@ -400,7 +400,6 @@ tinylegend = function(
   
   fklgnd.args = modifyList(
     legend_args,
-    # list(x = 0, y = 0, plot = FALSE),
     list(plot = FALSE),
     keep.null = TRUE
   )

--- a/R/draw_legend.R
+++ b/R/draw_legend.R
@@ -516,8 +516,7 @@ tinylegend = function(
 # For gradient (i.e., continuous color) legends, we'll role our own bespoke
 # legend function based on grDevices::as.raster
 
-gradient_legend = function(legend_args, fklgnd, lmar = NULL, outer_side, outer_end, outer_right = NULL, outer_bottom = NULL) {
-  if (is.null(lmar)) lmar = .tpar[["lmar"]]
+gradient_legend = function(legend_args, fklgnd, lmar, outer_side, outer_end, outer_right, outer_bottom) {
   pal = legend_args[["col"]]
   lgnd_labs = legend_args[["legend"]]
   if (!is.null(legend_args[["horiz"]])) horiz = legend_args[["horiz"]] else horiz = FALSE

--- a/R/draw_legend.R
+++ b/R/draw_legend.R
@@ -496,7 +496,15 @@ tinylegend = function(
         legend_args[["col"]] = legend_args[["pt.bg"]]
       }
     }
-    gradient_legend(legend_args = legend_args, lmar = lmar, outer_side = outer_side, outer_end = outer_end, outer_right = outer_right, outer_bottom = outer_bottom)
+    gradient_legend(
+      legend_args = legend_args,
+      fklgnd = fklgnd,
+      lmar = lmar,
+      outer_side = outer_side,
+      outer_end = outer_end,
+      outer_right = outer_right,
+      outer_bottom = outer_bottom
+    )
   } else {
     do.call("legend", legend_args)
   }
@@ -509,7 +517,7 @@ tinylegend = function(
 # For gradient (i.e., continuous color) legends, we'll role our own bespoke
 # legend function based on grDevices::as.raster
 
-gradient_legend = function(legend_args, lmar = NULL, outer_side, outer_end, outer_right = NULL, outer_bottom = NULL) {
+gradient_legend = function(legend_args, fklgnd, lmar = NULL, outer_side, outer_end, outer_right = NULL, outer_bottom = NULL) {
   if (is.null(lmar)) lmar = .tpar[["lmar"]]
   pal = legend_args[["col"]]
   lgnd_labs = legend_args[["legend"]]
@@ -536,18 +544,6 @@ gradient_legend = function(legend_args, lmar = NULL, outer_side, outer_end, oute
  
   if (inner) {
     
-    # "draw" fake legend
-    lgnd_labs_tmp = na.omit(legend_args[["legend"]])
-    if (length(lgnd_labs_tmp) < 5L) {
-      nmore = 5L - length(lgnd_labs_tmp)
-      lgnd_labs_tmp = c(lgnd_labs_tmp, rep("", nmore))
-    }
-    fklgnd.args = modifyList(
-      legend_args,
-      list(plot = FALSE, legend = lgnd_labs_tmp),
-      keep.null = TRUE
-    )
-    fklgnd = do.call("legend", fklgnd.args)
     fklgnd$rect$h = fklgnd$rect$h - (grconvertY(1.5 + 0.4, from="lines", to="user") - grconvertY(0, from="lines", to="user"))
     
     rasterbox[1] = fklgnd$rect$left

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1167,7 +1167,7 @@ tinyplot.default = function(
       y = y, ymax = ymax, ymin = ymin
     ),
     list = list(
-      add = add, 
+      add = add,
       cex_fct_adj = cex_fct_adj,
       facet.args = facet.args,
       facet_newlines = facet_newlines, facet_font = facet_font,
@@ -1322,7 +1322,8 @@ tinyplot.default = function(
           ngrps = ngrps,
           flip = flip,
           type_info = type_info,
-          facet_window_args = facet_window_args)
+          facet_window_args = facet_window_args
+        )
       }
     }
   }
@@ -1330,6 +1331,7 @@ tinyplot.default = function(
   # save end pars for possible recall later
   apar = par(no.readonly = TRUE)
   set_saved_par(when = "after", apar)
+
 }
 
 

--- a/man/draw_legend.Rd
+++ b/man/draw_legend.Rd
@@ -19,7 +19,8 @@ draw_legend(
   gradient = FALSE,
   lmar = NULL,
   has_sub = FALSE,
-  new_plot = TRUE
+  new_plot = TRUE,
+  draw = TRUE
 )
 }
 \arguments{
@@ -61,6 +62,10 @@ keyword position is "bottom!", in which case we need to bump the legend
 margin a bit further.}
 
 \item{new_plot}{Logical. Should we be calling plot.new internally?}
+
+\item{draw}{Logical. If \code{FALSE}, no legend is drawn but the sizes are
+returned. Note that a new (blank) plot frame will still need to be started
+in order to perform the calculations.}
 }
 \value{
 No return value, called for side effect of producing a(n empty) plot


### PR DESCRIPTION
Fixes #388 

I won't share just how many dead-ends I ended going down to resolve this. But I think I've cracked it now.

_tl;dr_ For reasons that I don't fully understand, we can't wrap the whole `draw_legend()` function in `recordGraphics()` without messing up source calls (which is what #388 was ultimately about.) At the same time, simply wrapping the final `legend`/`gradient_legend` calls didn't work either for the Positron case (per #377). _However_, it turns out that the compromise solution is to wrap the fake legend construction (which we need for calculating the plot offset for outside legend placement), the offset calculation, and the final legend plotting call together... but only these steps.

I operationalised this by creating a new internal `recordGraphics(tinylegend(...), ...)` function.