### PR TITLE
Tweak CSS of navbar

### DIFF
--- a/altdoc/custom.scss
+++ b/altdoc/custom.scss
@@ -9,3 +9,10 @@ $sidebar-fg: #000022;
 $sidebar-hl: #f51459;
 $toc-color: #f51459;
 $toc-hl: #f51459;
+
+
+.nav-link:hover, .nav-link.active {
+	color: #fcb6cb !important;
+	border-bottom: 2px solid;
+	font-weight: bold;
+}


### PR DESCRIPTION
Just a suggestion (cf https://github.com/grantmcdermott/tinyplot/issues/399#issuecomment-2888569259). The color is a bit lighter so I add the bottom bar to emphasize that the tab is selected / hovered.

Before:

![image](https://github.com/user-attachments/assets/fcc89f53-2b42-46af-920c-d0d4d6e8ab79)


After: 

![image](https://github.com/user-attachments/assets/37276b85-0eb2-47e9-b174-b9d630e48d3c)
