### PR TITLE
Smaller `n` in "tips and tricks"

### DIFF
--- a/vignettes/tips.qmd
+++ b/vignettes/tips.qmd
@@ -21,9 +21,10 @@ is too light:
 
 ```{r}
 library(tinyplot)
-x = rnorm(1e6)
-y = x + rnorm(1e6)
-z = sample(c("a", "b"), 1e6, replace = TRUE)
+n = 50000
+x = rnorm(n)
+y = x + rnorm(n)
+z = sample(c("a", "b"), n, replace = TRUE)
 dat = data.frame(x, y, z)
 tinyplot(y ~ x | z, data = dat, alpha = .1, pch = 19)
 ```


### PR DESCRIPTION
This vignette takes more than 2 min to render on my Windows machine. Using `n = 50000` doesn't change the main usecase.