### PR TITLE
Wrap saved_par in `recordGraphics`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,14 @@ where the formatting is also better._
 
 ### Bug fixes
 
+- Fixed a long-standing issue where resizing the plot window could cause
+  secondary plot layers---e.g., via `plt_add()`---to become misaligned in 
+  faceted plots (#313). This also resolves related alignment issues when adding
+  layers specifically within the Positron IDE
+  ([positron#7316](https://github.com/posit-dev/positron/issues/7316)).
+  **tinyplot** should now be fully compatible with Positron. (#438 @grantmcdermott)
+- Fixed a bug that resulted in y-axis labels being coerced to numeric for
+  `"p"`-alike plot types (including `"jitter"`) if `y` is a factor or character.
 - Safer handling of pre-plot hooks. Resolves an issue affecting how `tinyplot`
   behaves inside loops, particularly for themed plots where only the final plot
   was being drawn in Quarto/RMarkdown contexts. Special thanks to @hadley and @cderv

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -696,12 +696,11 @@ tinyplot.default = function(
 
   # catch for adding to existing facet plot
   if (!is.null(facet) && add) {
-    if (Sys.getenv("POSITRON") == 1 && interactive()) warning(
-      "Positron IDE detected.\n",
-      "Adding layers to a faceted tinyplot in Positron leads to known alignment errors. Please see:\n",
-      "https://github.com/posit-dev/positron/issues/7316"
+    recordGraphics(
+      par(get_saved_par(when = "after")),
+      list = list(),
+      env = getNamespace('tinyplot')
     )
-    par(get_saved_par(when = "after"))
   }
 
   # Capture deparsed expressions early, before x, y and by are evaluated
@@ -1364,8 +1363,14 @@ tinyplot.default = function(
   
   if (!add) {
     # save end pars for possible recall later
-    apar = par(no.readonly = TRUE)
-    set_saved_par(when = "after", apar)
+    recordGraphics(
+      {
+        apar = par(no.readonly = TRUE)
+        set_saved_par(when = "after", apar)
+      },
+      list = list(), 
+      env = getNamespace('tinyplot')
+    )
   }
 
 }

--- a/R/tinyplot_add.R
+++ b/R/tinyplot_add.R
@@ -15,21 +15,6 @@
 #'   mismatches. (An exception is when the original plot arguments---`x`, `y`,
 #'   etc.---are located in the global environment.)
 #'
-#' - There are two important limitations when adding layers to _faceted_ plots:
-#'
-#'   - Avoid resizing the graphics window after the first layer is drawn, since
-#'     it will lead to any subsequent layers being misaligned. This is a
-#'     limitation of base R's `graphics` engine and cannot be reliably preempted
-#'     or corrected by `tinyplot`. Note that resizing non-faceted plots is
-#'     always fine, though. See:
-#'     <https://github.com/grantmcdermott/tinyplot/issues/313>
-#'
-#'   - On Positron, specifically, alignment issues may occur even without
-#'     resizing. A warning will be triggered when (i) Positron is detected and
-#'     (ii) a user attempts to add layers to a faceted plot. Again, this issue
-#'     is not present for non-faceted plots. See the upstream bug report:
-#'     <https://github.com/posit-dev/positron/issues/7316>
-#' 
 #' - Automatic legends for the added elements will be turned off.
 #'
 #' @param ... All named arguments override arguments from the previous calls.

--- a/man/tinyplot_add.Rd
+++ b/man/tinyplot_add.Rd
@@ -33,20 +33,6 @@ We cannot guarantee correct behavior if the original plot was created with
 the atomic \code{\link{tinyplot.default}} method, due to potential environment
 mismatches. (An exception is when the original plot arguments---\code{x}, \code{y},
 etc.---are located in the global environment.)
-\item There are two important limitations when adding layers to \emph{faceted} plots:
-\itemize{
-\item Avoid resizing the graphics window after the first layer is drawn, since
-it will lead to any subsequent layers being misaligned. This is a
-limitation of base R's \code{graphics} engine and cannot be reliably preempted
-or corrected by \code{tinyplot}. Note that resizing non-faceted plots is
-always fine, though. See:
-\url{https://github.com/grantmcdermott/tinyplot/issues/313}
-\item On Positron, specifically, alignment issues may occur even without
-resizing. A warning will be triggered when (i) Positron is detected and
-(ii) a user attempts to add layers to a faceted plot. Again, this issue
-is not present for non-faceted plots. See the upstream bug report:
-\url{https://github.com/posit-dev/positron/issues/7316}
-}
 \item Automatic legends for the added elements will be turned off.
 }
 }


### PR DESCRIPTION
Supersedes #437 
Fixes https://github.com/grantmcdermott/tinyplot/issues/313
Fixes https://github.com/posit-dev/positron/issues/7316

It turns out that this simpler fix has the same effect of resolving the resizing issues, without the pathologies of #437. Thank goodness I'd been down the well for #394, otherwise I don't know if I would have cracked this.