### PR TITLE
Move altdoc to config

### DIFF
--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -34,15 +34,18 @@ jobs:
 
       - name: Dependencies
         run: ./run.sh install_all
+        with:
+          needs: website
+          cache: "always"
 
       - name: Build site
         run: |
           # If parallel = TRUE in render_docs()
-          # future::plan(future::multicore)
+          future::plan(future::multicore)
           install.packages(".", repos = NULL, type = "source")
           install.packages("pkgload")
           pkgload::load_all()
-          altdoc::render_docs(parallel = FALSE, freeze = FALSE)
+          altdoc::render_docs(parallel = TRUE, freeze = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -34,9 +34,12 @@ jobs:
 
       - name: Dependencies
         run: ./run.sh install_all
-        with:
-          needs: website
-          cache: "always"
+      
+      - name: Altdoc from GitHub
+        run: ./run.sh install_github etiennebacher/altdoc
+
+      - name: Additional Altdoc Dependency
+        run: ./run.sh install_r future.apply
 
       - name: Build site
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,6 @@ Authors@R:
 Description: Lightweight extension of the base R graphics system, with support
       for automatic legends, facets, themes, and various other enhancements.
 License: Apache License (>= 2)
-Remotes: etiennebacher/altdoc
 Depends:
   R (>= 4.0.0)
 Imports: 
@@ -46,7 +45,6 @@ Imports:
   tools,
   utils
 Suggests:
-  altdoc (>= 0.5.0.9000),
   fontquiver,
   png,
   rsvg,
@@ -54,6 +52,7 @@ Suggests:
   tinytest,
   tinysnapshot (>= 0.0.3),
   knitr
+Config/Needs/website: etiennebacher/altdoc, future.apply
 Encoding: UTF-8
 RoxygenNote: 7.3.2
 URL: https://grantmcdermott.com/tinyplot/


### PR DESCRIPTION
Testing the setup suggested by @etiennebacher here: https://github.com/etiennebacher/altdoc/issues/322#issuecomment-2794929124

This is so we can use the dev version of altdoc, but avoid having to comment things out for CRAN submission.

(I'm not sure that it will work given our reliance on Dirk's r-ci script, but let's see what CI throws up.)