### PR TITLE
Revert to remotes

### DIFF
--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -34,14 +34,18 @@ jobs:
 
       - name: Dependencies
         run: ./run.sh install_all
-      
-      - name: Altdoc from GitHub
+
+      - name: Altdoc deps
+        run: ./run.sh install_r future.apply gitcreds
+
+      - name: Setup GitHub creds for remotes
+        run: |
+          Rscript -e 'gitcreds::gitcreds_set(Sys.getenv("GH_TOKEN"))'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: ./run.sh install_github etiennebacher/altdoc
 
-      - name: Additional Altdoc Dependency
-        run: ./run.sh install_r future.apply
+      - name: Altdoc from GitHub
+        run: ./run.sh install_github etiennebacher/altdoc
 
       - name: Build site
         run: |

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -36,16 +36,12 @@ jobs:
         run: ./run.sh install_all
 
       - name: Altdoc deps
-        run: ./run.sh install_r future.apply gitcreds
-
-      - name: Setup GitHub creds for remotes
-        run: |
-          Rscript -e 'gitcreds::gitcreds_set(Sys.getenv("GH_TOKEN"))'
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: ./run.sh install_r future.apply
 
       - name: Altdoc from GitHub
-        run: ./run.sh install_github etiennebacher/altdoc
+        run: |
+          export GITHUB_PAT=${{ secrets.GH_TOKEN }}
+          ./run.sh install_github etiennebacher/altdoc
 
       - name: Build site
         run: |

--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -35,8 +35,10 @@ jobs:
       - name: Dependencies
         run: ./run.sh install_all
       
-      - name: Altdoc from R-universe
-        run: Rscript -e 'install.packages("altdoc", repos = "https://etiennebacher.r-universe.dev")'
+      - name: Altdoc from GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: ./run.sh install_github etiennebacher/altdoc
 
       - name: Additional Altdoc Dependency
         run: ./run.sh install_r future.apply


### PR DESCRIPTION
R-universe build doesn't work with r-ci (probably for override reasons) and just reverts to r2u/CRAN. (Details [here](https://github.com/grantmcdermott/tinyplot/actions/runs/16306381497/job/46053266747#step:7:165).) So now we try with `remotes` again and explicit GH token...