### PR TITLE
Fix some lints

### DIFF
--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -63,7 +63,7 @@ by_col = function(ngrps = 1L, col = NULL, palette = NULL, gradient = NULL, order
           "\nFewer colours ", ncolsstr, " provided than than there are groups ",
           ngrpsstr, ". Recycling to make up the shortfall."
         )
-        col = rep(col, length.out = ngrps)
+        col = rep_len(col, ngrps)
       }
   
     }
@@ -154,7 +154,7 @@ by_col = function(ngrps = 1L, col = NULL, palette = NULL, gradient = NULL, order
               "\nFewer colours ", ncolsstr, " provided than than there are groups ",
               ngrpsstr, ". Recycling to make up the shortfall."
             )
-            args = rep(args, length.out = ngrps)
+            args = rep_len(args, ngrps)
           }
         }
       } else {
@@ -188,7 +188,7 @@ by_col = function(ngrps = 1L, col = NULL, palette = NULL, gradient = NULL, order
               "\nFewer colours ", ncolsstr, " provided than than there are groups ",
               ngrpsstr, ". Recycling to make up the shortfall."
             )
-            args = rep(args, length.out = ngrps)
+            args = rep_len(args, ngrps)
           }
         }
       } else {

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -923,7 +923,7 @@ tinyplot.default = function(
   }
 
   # aesthetics by group: col, bg, etc.
-  ngrps = if (null_by) 1L else if (is.factor(by)) length(levels(by)) else if (by_continuous) 100L else length(unique(by))
+  ngrps = if (null_by) 1L else if (is.factor(by)) nlevels(by) else if (by_continuous) 100L else length(unique(by))
   pch = by_pch(ngrps = ngrps, type = type, pch = pch)
   lty = by_lty(ngrps = ngrps, type = type, lty = lty)
   lwd = by_lwd(ngrps = ngrps, type = type, lwd = lwd)

--- a/R/type_barplot.R
+++ b/R/type_barplot.R
@@ -95,7 +95,7 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
         if (!is.factor(datapoints$x)) datapoints$x = factor(datapoints$x)
         if (!is.null(xlevels)) {
           xlevels = if(is.numeric(xlevels)) levels(datapoints$x)[xlevels] else xlevels
-          if (any(is.na(xlevels)) || !all(xlevels %in% levels(datapoints$x))) warning("not all 'xlevels' correspond to levels of 'x'")
+          if (anyNA(xlevels) || !all(xlevels %in% levels(datapoints$x))) warning("not all 'xlevels' correspond to levels of 'x'")
           datapoints$x = factor(datapoints$x, levels = xlevels)
         }
         if (!is.null(xaxlabels)) levels(datapoints$x) <- xaxlabels
@@ -118,7 +118,7 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
           z[floor(mid) + 1L] = (mid - floor(mid)) * z[floor(mid) + 1L]
           sum(z[0L:floor(mid) + 1L], na.rm = TRUE)
         }
-        if (is.null(xlim)) xlim = c(1, length(levels(datapoints$x))) + c(-0.5, 0.5) * width
+        if (is.null(xlim)) xlim = c(1, nlevels(datapoints$x)) + c(-0.5, 0.5) * width
         if (is.null(ylim)) ylim = if (beside || length(unique(datapoints$by)) == 1L) {
           c(pmin(0, min(datapoints$y, na.rm = TRUE) * 1.02), pmax(0, max(datapoints$y, na.rm = TRUE) * 1.02))
         } else {
@@ -143,8 +143,8 @@ data_barplot = function(width = 5/6, beside = FALSE, center = FALSE, FUN = NULL,
         datapoints = lapply(sdat, function(df)  {
           
           df = df[order(df$x), , drop = FALSE]
-          nx = length(levels(df$x))
-          nb = length(levels(df$by))
+          nx = nlevels(df$x)
+          nb = nlevels(df$by)
           
           if (beside) {        
             xl = as.numeric(df$x) - width/2 + (as.numeric(df$by) - 1) * width/nb * as.numeric(!facet_by)

--- a/R/type_spineplot.R
+++ b/R/type_spineplot.R
@@ -136,13 +136,13 @@ data_spineplot = function(off = NULL, breaks = NULL, xlevels = xlevels, ylevels 
         x.categorical = is.factor(datapoints$x)
         if (!is.null(xlevels) && x.categorical) {
           xlevels = if(is.numeric(xlevels)) levels(datapoints$x)[xlevels] else xlevels
-          if (any(is.na(xlevels)) || !all(xlevels %in% levels(datapoints$x))) warning("not all 'xlevels' correspond to levels of 'x'")
+          if (anyNA(xlevels) || !all(xlevels %in% levels(datapoints$x))) warning("not all 'xlevels' correspond to levels of 'x'")
           datapoints$x = factor(datapoints$x, levels = xlevels)
           if (x_by) datapoints$by = datapoints$x
         }
         if (!is.null(ylevels)) {
           ylevels = if(is.numeric(ylevels)) levels(datapoints$y)[ylevels] else ylevels
-          if (any(is.na(ylevels)) || !all(ylevels %in% levels(datapoints$y))) warning("not all 'ylevels' correspond to levels of 'y'")
+          if (anyNA(ylevels) || !all(ylevels %in% levels(datapoints$y))) warning("not all 'ylevels' correspond to levels of 'y'")
           datapoints$y = factor(datapoints$y, levels = ylevels)
           if (y_by) datapoints$by = datapoints$y
         }
@@ -243,7 +243,7 @@ data_spineplot = function(off = NULL, breaks = NULL, xlevels = xlevels, ylevels 
         
         # catch for x_by / y/by
         if (isTRUE(x_by)) datapoints$by = factor(rep(xaxlabels, each = ny)) # each x label extends over ny rows
-        if (isTRUE(y_by)) datapoints$by = factor(rep(yaxlabels, length.out = nrow(datapoints)))
+        if (isTRUE(y_by)) datapoints$by = factor(rep_len(yaxlabels, nrow(datapoints)))
           
         ## grayscale flag
         grayscale = null_by && is.null(palette) && is.null(.tpar[["palette.qualitative"]])


### PR DESCRIPTION
Just ran the occasional `flir::fix_package(".", exclude_linters = c("equal_assignment", "numeric_leading_zero"))` to check whether it works fine on real-life packages:

- `any(is.na())` -> `anyNA()` (performance)
- `rep(col, length.out = ngrps)` -> `rep_len(col, ngrps)` (mostly readability, tiny bit of perf)
- `length(levels())` -> `nlevels()` (readability)

No problem to remove some of those if you prefer.