### PR TITLE
handle boxplot without y-variable in tinyplot.default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ where the formatting is also better._
 - Improved horizontal legend spacing, as well as multicolumn legend support. A
   new example in the "Tips & tricks" vignettes demonstrates the latter.
   (#446 @grantmcdermott)
+- Univariate boxplots (without grouping variable) are now handled in
+  `tinyplot.default()`, so that `tinyplot(x, type = "boxplot")` and
+  `tinyplot(~ x, type = "boxplot")` essentially produce the same output as
+  `boxplot(x)`. (#454 @zeileis)
 
 ### Internals
 

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -762,6 +762,11 @@ tinyplot.default = function(
       if (is.null(ylab)) ylab = "Density"
     } else if (type == "function") {
       if (is.null(ylab)) ylab = "Frequency"
+    } else if (type == "boxplot") {
+      y = x
+      x = rep.int("", length(y))
+      xlab = ""
+      xaxt = "a"
     } else if (!(type %in% c("histogram", "barplot"))) {
       y = x
       x = seq_along(x)


### PR DESCRIPTION
Fixes #453 

Like `boxplot(x)` it would be good if `tinyplot(x, type = "boxplot")` created a single boxplot without a grouping variable (and without corresponding labels on the x-axis).

I think that this is not easy to handle in `type_boxplot()` but requires a few simple workarounds in `tinyplot.default()` where the `is.null(y)` cases are handled. I've added:

```
    } else if (type == "boxplot") {
      y = x
      x = rep.int("", length(y))
      xlab = ""
      xaxt = "a"
```

With this both the default and the formula interface work:

```
tinyplot(Nile, type = "boxplot")
tinyplot(~ Nile, type = "boxplot")
```

<img width="1500" height="750" alt="tinyplot-boxplot" src="https://github.com/user-attachments/assets/6837d85b-3203-4ba9-abad-d4d993df1465" />

Grouping and faceting still works:

```
tinyplot(~ bill_len | species, data = penguins, type = "boxplot")
```

<img width="1500" height="750" alt="tinyplot-boxplot" src="https://github.com/user-attachments/assets/09680293-ec85-4632-ad73-c693997f92ce" />

```
tinyplot(~ bill_len, facet = ~ species, data = penguins, type = "boxplot")
```

<img width="1500" height="750" alt="tinyplot-boxplot" src="https://github.com/user-attachments/assets/dd5e20fa-4936-4af7-af85-bed3c613c7b5" />
