### PR TITLE
evaluate call from tinyplot_add() in parent.frame()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,12 @@ where the formatting is also better._
   `tinyplot(~ x, type = "boxplot")` essentially produce the same output as
   `boxplot(x)`. (#454 @zeileis)
 
+### Bug fixes
+
+- `tinyplot_add()` now evaluates the additional call in the environment from
+  which `tinyplot_add()` is called so that it also works in non-base environments
+  such as in function definitions. (#460 @zeileis)
+
 ### Internals
 
 - Move `altdoc` from `Suggests` to `Config/Needs/website`.

--- a/R/tinyplot_add.R
+++ b/R/tinyplot_add.R
@@ -63,7 +63,7 @@ tinyplot_add = function(...) {
   }
 
   cal[["add"]] = TRUE
-  eval(cal)
+  eval(cal, envir = parent.frame())
 }
 
 


### PR DESCRIPTION
Fixes #459 

`tinyplot_add()` now evaluates the additional call in the environment from which `tinyplot_add()` is called so that it also works in non-base environments such as in function definitions.