### PR TITLE
convert factor x/y to numeric in type_text

### DIFF
--- a/R/type_text.R
+++ b/R/type_text.R
@@ -51,6 +51,8 @@ data_text = function(labels, clim = c(0.5, 2.5)) {
       stop(msg, call. = FALSE)
     }
     datapoints$labels = labels
+    if (is.factor(datapoints$x)) datapoints$x = as.numeric(datapoints$x)
+    if (is.factor(datapoints$y)) datapoints$y = as.numeric(datapoints$y)
 
     # browser()
     bubble = FALSE


### PR DESCRIPTION
Fixes #469

`type_text()` now converts factor `x`/`y` variables to numeric so that it can be used for adding text to barplots etc.

Any potential problems with this for other plot types @grantmcdermott ?