### PR TITLE
Pass dynmar as explicit argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
   knitr
 Config/Needs/website: etiennebacher/altdoc, future.apply
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 URL: https://grantmcdermott.com/tinyplot/
 BugReports: https://github.com/grantmcdermott/tinyplot/issues
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,8 @@ where the formatting is also better._
     plot type internally coerces it to factor (e.g., `"boxplot"`)
 - `type_text()` can now also deal with factor `x`/`y` variables by converting
   them to numeric which helps to add text to barplots etc. (#470 @zeileis)
+- Fix bug where sourced (non-interactive) scripts with `tinytheme()` calls were
+  not inheriting the correct LHS margin spacing. (#475 @grantmcdermott)
 
 
 ### Internals

--- a/R/facet.R
+++ b/R/facet.R
@@ -33,7 +33,8 @@ draw_facet_window = function(
     has_legend,
     type,
     x, xmax, xmin,
-    y, ymax, ymin
+    y, ymax, ymin,
+    dynmar = NULL
     ) {
   
   # if add is TRUE, just return inputs without any calculations
@@ -53,7 +54,8 @@ draw_facet_window = function(
   }
 
   ## dynamic margins flag
-  dynmar = isTRUE(.tpar[["dynmar"]])
+  if (is.null(dynmar)) dynmar = get_tpar("dynmar")
+  dynmar = isTRUE(dynmar)
   
   ## optionally allow to modify the style of axis interval calculation
   if (!is.null(xaxs)) par(xaxs = xaxs)

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1229,7 +1229,8 @@ tinyplot.default = function(
       has_legend = has_legend,
       type = type,
       x = x, xmax = xmax, xmin = xmin,
-      y = y, ymax = ymax, ymin = ymin
+      y = y, ymax = ymax, ymin = ymin,
+      dynmar = dynmar
     ),
     list = list(
       add = add,
@@ -1252,7 +1253,8 @@ tinyplot.default = function(
       has_legend = has_legend,
       type = type,
       x = datapoints$x, xmax = datapoints$xmax, xmin = datapoints$xmin,
-      y = datapoints$y, ymax = datapoints$ymax, ymin = datapoints$ymin
+      y = datapoints$y, ymax = datapoints$ymax, ymin = datapoints$ymin,
+      dynmar = get_tpar("dynmar") # https://github.com/grantmcdermott/tinyplot/issues/474
     ),
     getNamespace("tinyplot")
   )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,6 +18,7 @@
     "cex_fct_adj",
     "dots",
     "draw",
+    "dynmar",
     "facet_bg",
     "facet_border",
     "facet_col",

--- a/man/facet.Rd
+++ b/man/facet.Rd
@@ -53,7 +53,8 @@ draw_facet_window(
   xmin,
   y,
   ymax,
-  ymin
+  ymin,
+  dynmar = NULL
 )
 
 facet_layout(facet, add = FALSE, facet.args = list())


### PR DESCRIPTION
Fixes #474

I tracked the issue down to the fact the draw_facet_window ([here](https://github.com/grantmcdermott/tinyplot/blob/c17bbd72b343a6d469e0aba5b82fd170bc12001e/R/tinyplot.R#L1207)) is actually being called twice and, during the second time, it's dropping the `tpar` hooks.

While I'm not 100% certain of the mechanics, I'm pretty confident that this is another `recordGraphics` / `replayGraphics` gotcha. (Side note: but I think this only appears to affect `"dynmar"` among all of the sundry `tpar` parameters, because the rest are handled by native hooks that kick in once plot.new() is called.)

At any rate, the simple solution that I use here is just to pass `dynmar` as an explicit argument in `recordGraphics(draw_facet_window, list(..., dynmar = get_par("dynmar"))` I thought about passing the whole `tpar()` list as an argument, since we actually extract other `tpar` parameters, but erred on the conservative side since only `dynmar` appears to be affected.
I