### PR TITLE
Add `cex` as explicit argument to tinytheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,8 +40,10 @@ where the formatting is also better._
     plot type internally coerces it to factor (e.g., `"boxplot"`)
 - `type_text()` can now also deal with factor `x`/`y` variables by converting
   them to numeric which helps to add text to barplots etc. (#470 @zeileis)
-- Fix bug where sourced (non-interactive) scripts with `tinytheme()` calls were
-  not inheriting the correct parameters and spacing. (#475, #481 @grantmcdermott)
+- Fixed some `tinytheme()` bugs.
+  - Sourced (non-interactive) scripts with `tinytheme()` calls now inherit the
+    correct parameters and spacing. (#475, #481 @grantmcdermott)
+  - Custom `cex` theme settings are now reset correctly. (#482 @grantmcdermott)
 
 
 ### Internals

--- a/R/tinytheme.R
+++ b/R/tinytheme.R
@@ -183,6 +183,7 @@ theme_default = list(
   adj.sub = par("adj"), # 0.5,
   bg = "white", # par("bg") # "white"
   bty = par("bty"), #"o",
+  cex = par("cex"), #1,
   cex.axis = par("cex.axis"), #1,
   cex.main = par("cex.main"), #1.2,
   cex.xlab = par("cex.axis"), #1,


### PR DESCRIPTION
Closes #477

``` r
pkgload::load_all('~/Documents/Projects/tinyplot')
#> ℹ Loading tinyplot
tinyplot(dist ~ speed, data = cars)
```

![](https://i.imgur.com/2d7PHBR.png)<!-- -->

``` r
tinytheme("clean2", pch = 17, cex = 3)
tinyplot(dist ~ speed, data = cars)
```

![](https://i.imgur.com/8mhUQvP.png)<!-- -->

``` r
tinytheme()
tinyplot(dist ~ speed, data = cars)
```

![](https://i.imgur.com/yIGxBBW.png)<!-- -->

<sup>Created on 2025-09-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>