### PR TITLE
Bump altdoc verison

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Suggests:
   tinytest,
   tinysnapshot (>= 0.0.3),
   knitr
-Config/Needs/website: etiennebacher/altdoc, future.apply
+Config/Needs/website: altdoc (>= 0.6.0), future.apply
 Encoding: UTF-8
 RoxygenNote: 7.3.3
 URL: https://grantmcdermott.com/tinyplot/


### PR DESCRIPTION
v0.6.0 is on CRAN, so no need to install the dev version anymore