### PR TITLE
make tinyplot_add compatible with do.call(tinyplot)

### DIFF
--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -652,10 +652,10 @@ tinyplot.default = function(
   assert_logical(add)
   if (!add) {
     calls = sys.calls()
-    tinyplot_calls = "(^tinyplot$)|(^tinyplot::tinyplot$)|(^plt$)|(^tinyplot::plt)|(^tinyplot:::)"
-    idx = grep(tinyplot_calls, sapply(calls, function(k) k[[1]]))
+    is_tinyplot_call <- function(x) identical(tinyplot, try(eval(x[[1L]]), silent = TRUE))
+    idx = which(vapply(calls, is_tinyplot_call, FALSE))
     if (length(idx) > 0) {
-      set_environment_variable(.last_call = calls[[idx[1]]])
+      set_environment_variable(.last_call = calls[[idx[1L]]])
     }
   }
 


### PR DESCRIPTION
Fixes #499 

The `.last_call` of the `tinyplot()` generic is now determined by comparing the _functions_ called in `sys.calls()` rather than their _names_ as suggested by @FlorianSchwendinger.

This makes it compatible with usage in `do.call()` or when using a custom copy of the generic.

```
do.call(tinyplot, list(x = 1:5, y = sin(1:5)))
do.call(tinyplot_add, list(type = "h"))

myplot = tinyplot
myplot_add = tinyplot_add
myplot(x = 1:5, y = sin(1:5))
myplot_add(type = "h")
```

<img width="900" height="450" alt="tinyplot-add" src="https://github.com/user-attachments/assets/9d7ab3b5-1e6d-4a4c-a8f6-0b69db09fecf" />
