### PR TITLE
Fix dynamic theme compabiltity with `legend = "top!"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,9 @@ visualizations.
     title to whatever is below it (plot box or subtitle top); `gap.sub`
     sets the gap from the subtitle to the plot box. Both default to `0.7`.
     (#597)
+  - Dynamic themes now play nicely with `legend = "top!"`. The title,
+    subtitle, and legend stack correctly above the plot region with proper
+    spacing. (#605)
 
 - **Theme refinements**. The `"tufte"` and `"void"` themes are now dynamic
   (responsive margins). The `"ipsum"` theme has been overhauled (bold title, no
@@ -122,6 +125,12 @@ visualizations.
   now vertically centered within the background rect. (#586 @grantmcdermott)
 - Fixed Issue #593 where `palette.qualitative` in themes could not be a
   function. Thanks to @katrinabrock for the report. (#594 @zeileis)
+- Fixed `legend = "top!"` under dynamic themes where the main title was
+  invisible and the legend overlapped the plot region. Title and subtitle
+  (when `side.sub = 3`) now stack correctly above the legend with exact
+  positioning that matches other legend positions. Also fixed margin state
+  corruption when switching between outer legend positions across successive
+  plots. (#604, #605 @grantmcdermott)
 
 
 ## v0.6.1

--- a/R/legend.R
+++ b/R/legend.R
@@ -851,6 +851,10 @@ build_legend_env = function(
 #'   in order to perform the calculations.
 #' @param soma_target Numeric. Shared outer margin target (in lines) for
 #'   multi-legend alignment. If `NULL`, each legend computes its own margin.
+#' @param main_lines Integer. Number of lines in the main title (0 if none).
+#' @param dynmar_title_mar Numeric or `NULL`. The pre-computed `dynmar_computed[3]`
+#'   value for "top!" legends under dynmar themes. When set, the legend margin
+#'   formula uses this directly to ensure correct title positioning.
 #'
 #' @returns No return value, called for side effect of producing a(n empty) plot
 #'   with a legend in the margin.

--- a/R/legend.R
+++ b/R/legend.R
@@ -753,7 +753,6 @@ build_legend_env = function(
   has_cap = FALSE,
   cap_text = NULL,
   new_plot = TRUE,
-  main_lines = 0L,
   dynmar_title_mar = NULL
 ) {
   # Create legend environment
@@ -767,7 +766,6 @@ build_legend_env = function(
   legend_env$cap_text = cap_text
   legend_env$new_plot = new_plot
   legend_env$dynmar = isTRUE(.tpar[["dynmar"]])
-  legend_env$main_lines = main_lines
   legend_env$dynmar_title_mar = dynmar_title_mar
   legend_env$topmar_epsilon = 0.1
 
@@ -851,7 +849,6 @@ build_legend_env = function(
 #'   in order to perform the calculations.
 #' @param soma_target Numeric. Shared outer margin target (in lines) for
 #'   multi-legend alignment. If `NULL`, each legend computes its own margin.
-#' @param main_lines Integer. Number of lines in the main title (0 if none).
 #' @param dynmar_title_mar Numeric or `NULL`. The pre-computed `dynmar_computed[3]`
 #'   value for "top!" legends under dynmar themes. When set, the legend margin
 #'   formula uses this directly to ensure correct title positioning.
@@ -942,7 +939,6 @@ draw_legend = function(
   new_plot = TRUE,
   draw = TRUE,
   soma_target = NULL,
-  main_lines = 0L,
   dynmar_title_mar = NULL
 ) {
   if (is.null(lmar)) {
@@ -994,7 +990,6 @@ draw_legend = function(
     has_cap = has_cap,
     cap_text = cap_text,
     new_plot = new_plot,
-    main_lines = main_lines,
     dynmar_title_mar = dynmar_title_mar
   )
 

--- a/R/legend.R
+++ b/R/legend.R
@@ -118,9 +118,10 @@ legend_outer_margins = function(legend_env, apply = TRUE) {
         omar[1] = omar[1] + 1 * par("cex.sub")
       }
     } else {
-      # For "top!", expand existing inner margin rather than outer margin
-      ooma[3] = ooma[3] + legend_env$topmar_epsilon
-      par(oma = ooma)
+      if (is.null(legend_env$dynmar_title_mar)) {
+        ooma[3] = ooma[3] + legend_env$topmar_epsilon
+        par(oma = ooma)
+      }
     }
     par(mar = omar)
 
@@ -135,8 +136,10 @@ legend_outer_margins = function(legend_env, apply = TRUE) {
             omar[1] = omar[1] + 1 * par("cex.sub")
           }
         } else {
-          ooma[3] = ooma[3] + legend_env$topmar_epsilon
-          par(oma = ooma)
+          if (is.null(legend_env$dynmar_title_mar)) {
+            ooma[3] = ooma[3] + legend_env$topmar_epsilon
+            par(oma = ooma)
+          }
         }
         par(mar = omar)
       }

--- a/R/legend.R
+++ b/R/legend.R
@@ -174,8 +174,13 @@ legend_outer_margins = function(legend_env, apply = TRUE) {
           legend_env$ooma[1] = legend_env$ooma[1] + cex_cap + 0.2
         }
       } else {
-        legend_env$omar[3] = legend_env$omar[3] + soma - legend_env$topmar_epsilon
+        if (!is.null(legend_env$dynmar_title_mar)) {
+          legend_env$omar[3] = legend_env$dynmar_title_mar + soma
+        } else {
+          legend_env$omar[3] = legend_env$omar[3] + soma - legend_env$topmar_epsilon
+        }
         par(mar = legend_env$omar)
+        set_environment_variable(.top_legend_soma = soma)
       }
     }
     par(oma = legend_env$ooma)
@@ -278,8 +283,13 @@ tinylegend = function(legend_env) {
         legend_env$ooma[1] = legend_env$ooma[1] + cex_cap + 0.2
       }
     } else {
-      legend_env$omar[3] = legend_env$omar[3] + soma - legend_env$topmar_epsilon
+      if (!is.null(legend_env$dynmar_title_mar)) {
+        legend_env$omar[3] = legend_env$dynmar_title_mar + soma
+      } else {
+        legend_env$omar[3] = legend_env$omar[3] + soma - legend_env$topmar_epsilon
+      }
       par(mar = legend_env$omar)
+      set_environment_variable(.top_legend_soma = soma)
     }
   }
   par(oma = legend_env$ooma)
@@ -739,7 +749,9 @@ build_legend_env = function(
   has_sub = FALSE,
   has_cap = FALSE,
   cap_text = NULL,
-  new_plot = TRUE
+  new_plot = TRUE,
+  main_lines = 0L,
+  dynmar_title_mar = NULL
 ) {
   # Create legend environment
   legend_env = new.env(parent = emptyenv())
@@ -752,6 +764,8 @@ build_legend_env = function(
   legend_env$cap_text = cap_text
   legend_env$new_plot = new_plot
   legend_env$dynmar = isTRUE(.tpar[["dynmar"]])
+  legend_env$main_lines = main_lines
+  legend_env$dynmar_title_mar = dynmar_title_mar
   legend_env$topmar_epsilon = 0.1
 
   # Build legend arguments (modifies legend_env in-place)
@@ -920,7 +934,9 @@ draw_legend = function(
   cap_text = NULL,
   new_plot = TRUE,
   draw = TRUE,
-  soma_target = NULL
+  soma_target = NULL,
+  main_lines = 0L,
+  dynmar_title_mar = NULL
 ) {
   if (is.null(lmar)) {
     lmar = tpar("lmar")
@@ -942,6 +958,7 @@ draw_legend = function(
   if (!dynmar) {
     restore_margin_inner(par("oma"), topmar_epsilon = 0.1)
   }
+  set_environment_variable(.top_legend_soma = NULL)
 
   # Build legend environment
   legend_env = build_legend_env(
@@ -969,7 +986,9 @@ draw_legend = function(
     has_sub = has_sub,
     has_cap = has_cap,
     cap_text = cap_text,
-    new_plot = new_plot
+    new_plot = new_plot,
+    main_lines = main_lines,
+    dynmar_title_mar = dynmar_title_mar
   )
 
   # Extract and strip ljust before any legend() calls

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1078,7 +1078,9 @@ tinyplot.default = function(
     # region meets the legend's oma flush. Only .theme_mar is zeroed — the
     # axis-driven bumps in .dyn (tick rows, axis labels, main/sub) are kept
     # so that "left!" and "bottom!" legends don't collide with axis content.
-    .theme_mar[.outer_sides] = 0
+    # Exception: "top!" lives in mar[3] (not oma), so keep the baseline padding.
+    .outer_sides_oma = .outer_sides & c(TRUE, TRUE, FALSE, TRUE)
+    .theme_mar[.outer_sides_oma] = 0
 
     # whtsbp uses strwidth(units="figure") + grconvertX("nfc" → "lines"),
     # both of which give device-default font metrics without requiring
@@ -1157,7 +1159,9 @@ tinyplot.default = function(
         cex = lgnd_cex,
         has_sub = has_sub,
         has_cap = has_cap,
-        cap_text = cap
+        cap_text = cap,
+        main_lines = text_line_count(main),
+        dynmar_title_mar = if (!is.null(dynmar_computed) && .outer_sides[3] && text_line_count(main) >= 1L) dynmar_computed[3] else NULL
       )
     } else {
       ## multi-legend case...
@@ -1199,6 +1203,9 @@ tinyplot.default = function(
     # Reinstate dynmar margins and user coordinates after draw_legend
     # (which may have called plot.new and reset par via hooks).
     if (!is.null(dynmar_computed)) {
+      if (has_legend && .outer_sides[3]) {
+        dynmar_computed[3] = par("mar")[3] - .whtsbp[3]
+      }
       par(mar = dynmar_computed + .whtsbp)
       if (!is.null(xlim) && !is.null(ylim)) {
         plot.window(xlim = xlim, ylim = ylim)

--- a/R/tinyplot.R
+++ b/R/tinyplot.R
@@ -1160,7 +1160,6 @@ tinyplot.default = function(
         has_sub = has_sub,
         has_cap = has_cap,
         cap_text = cap,
-        main_lines = text_line_count(main),
         dynmar_title_mar = if (!is.null(dynmar_computed) && .outer_sides[3] && text_line_count(main) >= 1L) dynmar_computed[3] else NULL
       )
     } else {

--- a/R/tinytheme.R
+++ b/R/tinytheme.R
@@ -102,10 +102,6 @@
 #' If you supply an explicit `mgp` value, it is used as-is and the primitives
 #' are ignored.
 #'
-#' **Caveats.** Known `tinytheme` limitations include:
-#'
-#' - Themes do not work well when `legend = "top!"`.
-#'
 #' @return The function returns nothing. It is called for its side effects.
 #' 
 #' @seealso [`tpar`] which does the heavy lifting under the hood.

--- a/R/title.R
+++ b/R/title.R
@@ -20,7 +20,11 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
   # include a 0.1 epsilon bump, which we're using to reset the tinyplot
   # window in case of recursive "top!" calls. (See draw_legend code.)
 
-  if (isTRUE(adj_title)) {
+  if (isTRUE(adj_title) && isTRUE(get_tpar("dynmar", FALSE))) {
+    gap_main = get_tpar("gap.main", 0.7)
+    top_soma = get_environment_variable(".top_legend_soma") %||% 0
+    line_main = top_soma + gap_main - 0.1
+  } else if (isTRUE(adj_title)) {
     line_main = par("mar")[3] - opar[["mar"]][3] + 1.7 + 0.1
   } else if (isTRUE(get_tpar("dynmar", FALSE))) {
     gap_main = get_tpar("gap.main", 0.7)
@@ -68,6 +72,10 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
     # `line_main`, extra lines extend upward). The reserved top margin
     # already accounts for (N-1)*cex_main extra lines, so no line-shift
     # adjustment is needed here.
+    # For "top!" + dynmar, line_main exceeds par("mar")[3] so we need xpd=NA
+    # to allow drawing outside the clipping region.
+    .oxpd = par("xpd")
+    if (!is.null(line_main) && line_main > par("mar")[3] - 1) par(xpd = NA)
     args = list(
       main = main,
       line = line_main,
@@ -77,6 +85,7 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
       adj = get_tpar(c("adj.main", "adj"), 3))
     args = Filter(function(x) !is.null(x), args)
     do.call(title, args)
+    par(xpd = .oxpd)
   }
 
 

--- a/R/title.R
+++ b/R/title.R
@@ -50,6 +50,10 @@ draw_title = function(main, sub, cap, xlab, ylab, legend, legend_args, opar,
     if (isTRUE(get_tpar("side.sub", 1) == 3)) {
       gap_sub = get_tpar("gap.sub", 0.7)
       line_sub = get_tpar("line.sub", gap_sub - 0.1)
+      if (isTRUE(adj_title) && isTRUE(get_tpar("dynmar", FALSE))) {
+        top_soma = get_environment_variable(".top_legend_soma") %||% 0
+        line_sub = top_soma + gap_sub - 0.1
+      }
     } else {
       line_sub = get_tpar("line.sub", 4)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -196,24 +196,22 @@ restore_margin_inner = function(ooma, topmar_epsilon = 0.1) {
   ooma = par("oma")
   omar = par("mar")
 
-  if (!any(ooma != 0)) return(invisible(NULL))
+  # omd reset (from restore_margin_outer) clears oma as a side-effect, so
+  # detect dirty margins directly from mar values rather than relying on oma.
+  top_dirty = omar[3] > 4.1
+  right_dirty = omar[4] == 0
+  left_dirty = ooma[2] != 0 && omar[2] == par("mgp")[1] + 1 * par("cex.lab")
+  bottom_dirty = ooma[1] != 0 && omar[1] == par("mgp")[1] + 1 * par("cex.lab")
+
+  if (!any(ooma != 0) && !top_dirty && !right_dirty) return(invisible(NULL))
 
   # Restore inner margin defaults (in case affected by preceding tinyplot call)
-  if (any(ooma != 0)) {
-    if (ooma[1] != 0 && omar[1] == par("mgp")[1] + 1 * par("cex.lab")) {
-      omar[1] = 5.1
-    }
-    if (ooma[2] != 0 && omar[2] == par("mgp")[1] + 1 * par("cex.lab")) {
-      omar[2] = 4.1
-    }
-    if (ooma[3] == topmar_epsilon && omar[3] != 4.1) {
-      omar[3] = 4.1
-    }
-    if (ooma[4] != 0 && omar[4] == 0) {
-      omar[4] = 2.1
-    }
-    par(mar = omar)
-  }
+  if (bottom_dirty) omar[1] = 5.1
+  if (left_dirty) omar[2] = 4.1
+  if (top_dirty) omar[3] = 4.1
+  if (right_dirty) omar[4] = 2.1
+  par(mar = omar)
+
   # Restore outer margin defaults (with a catch for custom mfrow plots)
   if (all(par("mfrow") == c(1, 1))) {
     par(omd = c(0, 1, 0, 1))

--- a/inst/tinytest/_tinysnapshot/legend_right_dynmar_after_top.svg
+++ b/inst/tinytest/_tinysnapshot/legend_right_dynmar_after_top.svg
@@ -1,0 +1,252 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMS40NHw0OTUuMzZ8OC42NHw1MDIuNTY='>
+    <rect x='1.44' y='8.64' width='493.92' height='493.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMS40NHw0OTUuMzZ8OC42NHw1MDIuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='424.66' y='219.60' width='78.36' height='72.00' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<circle cx='435.46' cy='248.40' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='435.46' cy='262.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='435.46' cy='277.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<text x='430.04' y='234.00' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.69px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text x='446.26' y='252.53' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='35.34px' lengthAdjust='spacingAndGlyphs'>setosa</text>
+<text x='446.26' y='266.93' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='51.36px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
+<text x='446.26' y='281.33' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MTAuMjZ8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='410.26' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MTAuMjZ8MC4wMHw1MDQuMDA=)'>
+<text x='233.63' y='499.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.36px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,232.56) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.70px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='70.08' y1='456.48' x2='402.72' y2='456.48' style='stroke-width: 0.75;' />
+<line x1='70.08' y1='456.48' x2='70.08' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='125.52' y1='456.48' x2='125.52' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='180.96' y1='456.48' x2='180.96' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='236.40' y1='456.48' x2='236.40' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='291.84' y1='456.48' x2='291.84' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='347.28' y1='456.48' x2='347.28' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='402.72' y1='456.48' x2='402.72' y2='460.80' style='stroke-width: 0.75;' />
+<text x='70.08' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='125.52' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='180.96' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='236.40' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='291.84' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='347.28' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='402.72' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='56.99' y1='416.86' x2='56.99' y2='13.71' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='416.86' x2='52.67' y2='416.86' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='359.26' x2='52.67' y2='359.26' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='301.67' x2='52.67' y2='301.67' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='244.08' x2='52.67' y2='244.08' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='186.49' x2='52.67' y2='186.49' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='128.89' x2='52.67' y2='128.89' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='71.30' x2='52.67' y2='71.30' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='13.71' x2='52.67' y2='13.71' style='stroke-width: 0.75;' />
+<text x='46.91' y='420.99' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='46.91' y='363.39' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='46.91' y='305.80' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text x='46.91' y='248.21' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text x='46.91' y='190.62' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text x='46.91' y='133.02' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text x='46.91' y='75.43' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='46.91' y='17.84' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='56.99,456.48 410.26,456.48 410.26,8.64 56.99,8.64 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTYuOTl8NDEwLjI2fDguNjR8NDU2LjQ4'>
+    <rect x='56.99' y='8.64' width='353.27' height='447.84' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTYuOTl8NDEwLjI2fDguNjR8NDU2LjQ4)'>
+<circle cx='92.25' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='370.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.71' cy='393.82' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='405.34' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='108.89' cy='313.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='405.34' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='428.37' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='370.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='313.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='103.34' cy='382.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='382.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='75.62' cy='439.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='81.16' cy='267.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.71' cy='313.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='108.89' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='108.89' cy='313.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='70.08' cy='405.34' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='108.89' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='119.97' cy='382.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='103.34' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='103.34' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='336.23' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='336.23' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='103.34' cy='393.82' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='103.34' cy='382.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='313.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='336.23' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='301.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='370.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='81.16' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.71' cy='301.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='370.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.71' cy='428.37' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.71' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.71' cy='416.86' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.71' cy='428.37' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='103.34' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='119.97' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='382.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='103.34' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='405.34' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='97.80' cy='324.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='92.25' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='275.21' cy='128.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='264.12' cy='198.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.30' cy='140.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='236.40' cy='301.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='269.67' cy='186.49' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='264.12' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='275.21' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='197.59' cy='370.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='269.67' cy='174.97' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='230.86' cy='336.23' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='208.68' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='247.49' cy='255.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='236.40' cy='244.08' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='275.21' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='214.22' cy='290.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.58' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='264.12' cy='290.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='241.94' cy='267.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='264.12' cy='221.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='230.86' cy='290.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='280.75' cy='255.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='236.40' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.30' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='275.21' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='253.03' cy='198.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.58' cy='174.97' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='280.75' cy='151.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='291.84' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='264.12' cy='244.08' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='208.68' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='225.31' cy='301.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='219.77' cy='301.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='230.86' cy='267.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='297.39' cy='244.08' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='264.12' cy='313.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='264.12' cy='244.08' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='275.21' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.58' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='241.94' cy='290.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='236.40' cy='301.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.58' cy='301.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='269.67' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='236.40' cy='267.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='197.59' cy='359.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='247.49' cy='290.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='247.49' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='247.49' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='253.03' cy='221.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='180.96' cy='347.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='241.94' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='347.28' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='297.39' cy='267.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.74' cy='117.37' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='325.11' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='336.20' cy='186.49' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='380.55' cy='59.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='264.12' cy='370.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='363.92' cy='94.34' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='336.20' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='352.83' cy='105.86' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='297.39' cy='186.49' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='308.47' cy='198.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='319.56' cy='151.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='291.84' cy='278.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='297.39' cy='267.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='308.47' cy='198.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='319.56' cy='186.49' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='386.09' cy='48.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='397.18' cy='48.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='291.84' cy='244.08' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='330.65' cy='140.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='286.30' cy='290.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='386.09' cy='48.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='286.30' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='330.65' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='347.28' cy='105.86' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='280.75' cy='221.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='286.30' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='325.11' cy='198.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='336.20' cy='105.86' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='352.83' cy='82.82' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.46' cy='25.23' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='325.11' cy='198.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='297.39' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='325.11' cy='232.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='352.83' cy='48.26' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='325.11' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='319.56' cy='198.00' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='280.75' cy='244.08' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='314.02' cy='140.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='325.11' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='297.39' cy='140.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='297.39' cy='267.12' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.74' cy='151.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='330.65' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='302.93' cy='163.45' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='291.84' cy='209.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='302.93' cy='186.49' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='314.02' cy='221.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='297.39' cy='255.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/legend_top_dynmar_after_right.svg
+++ b/inst/tinytest/_tinysnapshot/legend_top_dynmar_after_right.svg
@@ -1,0 +1,244 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMS40NHw0OTUuMzZ8OC42NHw1MDIuNTY='>
+    <rect x='1.44' y='8.64' width='493.92' height='493.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMS40NHw0OTUuMzZ8OC42NHw1MDIuNTY=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='141.28' y='29.09' width='214.25' height='43.20' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<circle cx='152.08' cy='57.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='215.68' cy='57.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='295.29' cy='57.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<text x='248.40' y='43.49' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.69px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text x='162.88' y='62.02' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.00px' lengthAdjust='spacingAndGlyphs'>setosa  </text>
+<text x='226.48' y='62.02' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='58.02px' lengthAdjust='spacingAndGlyphs'>versicolor  </text>
+<text x='306.09' y='62.02' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+<text x='56.99' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='35.19px' lengthAdjust='spacingAndGlyphs'>Hello</text>
+<text x='276.18' y='499.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.36px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,272.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.70px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+<line x1='73.23' y1='456.48' x2='486.00' y2='456.48' style='stroke-width: 0.75;' />
+<line x1='73.23' y1='456.48' x2='73.23' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='142.02' y1='456.48' x2='142.02' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='210.82' y1='456.48' x2='210.82' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='279.62' y1='456.48' x2='279.62' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='348.41' y1='456.48' x2='348.41' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='417.21' y1='456.48' x2='417.21' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='486.00' y1='456.48' x2='486.00' y2='460.80' style='stroke-width: 0.75;' />
+<text x='73.23' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='142.02' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='210.82' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='279.62' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='348.41' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='417.21' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='486.00' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='56.99' y1='423.89' x2='56.99' y2='92.30' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='423.89' x2='52.67' y2='423.89' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='376.52' x2='52.67' y2='376.52' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='329.15' x2='52.67' y2='329.15' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='281.78' x2='52.67' y2='281.78' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='234.41' x2='52.67' y2='234.41' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='187.04' x2='52.67' y2='187.04' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='139.67' x2='52.67' y2='139.67' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='92.30' x2='52.67' y2='92.30' style='stroke-width: 0.75;' />
+<text x='46.91' y='428.02' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='46.91' y='380.65' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='46.91' y='333.28' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text x='46.91' y='285.91' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text x='46.91' y='238.54' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text x='46.91' y='191.17' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text x='46.91' y='143.80' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='46.91' y='96.43' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='56.99,456.48 495.36,456.48 495.36,88.13 56.99,88.13 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTYuOTl8NDk1LjM2fDg4LjEzfDQ1Ni40OA=='>
+    <rect x='56.99' y='88.13' width='438.37' height='368.35' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTYuOTl8NDk1LjM2fDg4LjEzfDQ1Ni40OA==)'>
+<circle cx='100.75' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='404.94' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='433.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='80.11' cy='442.84' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='73.23' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='404.94' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='433.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='423.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='433.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='348.10' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='327.77' cy='187.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='224.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='291.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='252.10' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='291.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='224.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='205.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='348.41' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='265.86' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.98' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='355.29' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='210.82' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='417.21' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='177.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='458.49' cy='130.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='314.01' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='437.85' cy='158.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='168.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='205.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='479.12' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='417.21' cy='168.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='168.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='149.14' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='444.73' cy='101.77' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='205.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='291.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/legend_top_dynmar_notitle.svg
+++ b/inst/tinytest/_tinysnapshot/legend_top_dynmar_notitle.svg
@@ -1,0 +1,243 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='141.28' y='10.08' width='214.25' height='43.20' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<circle cx='152.08' cy='38.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='215.68' cy='38.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='295.29' cy='38.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<text x='248.40' y='24.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.69px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text x='162.88' y='43.01' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.00px' lengthAdjust='spacingAndGlyphs'>setosa  </text>
+<text x='226.48' y='43.01' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='58.02px' lengthAdjust='spacingAndGlyphs'>versicolor  </text>
+<text x='306.09' y='43.01' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8Mi44OHw1MDQuMDA='>
+    <rect x='0.00' y='2.88' width='504.00' height='501.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8Mi44OHw1MDQuMDA=)'>
+<text x='276.18' y='499.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.36px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,262.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.70px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='73.23' y1='456.48' x2='486.00' y2='456.48' style='stroke-width: 0.75;' />
+<line x1='73.23' y1='456.48' x2='73.23' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='142.02' y1='456.48' x2='142.02' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='210.82' y1='456.48' x2='210.82' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='279.62' y1='456.48' x2='279.62' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='348.41' y1='456.48' x2='348.41' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='417.21' y1='456.48' x2='417.21' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='486.00' y1='456.48' x2='486.00' y2='460.80' style='stroke-width: 0.75;' />
+<text x='73.23' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='142.02' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='210.82' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='279.62' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='348.41' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='417.21' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='486.00' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='56.99' y1='422.21' x2='56.99' y2='73.51' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='422.21' x2='52.67' y2='422.21' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='372.39' x2='52.67' y2='372.39' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='322.58' x2='52.67' y2='322.58' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='272.76' x2='52.67' y2='272.76' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='222.95' x2='52.67' y2='222.95' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='173.14' x2='52.67' y2='173.14' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='123.32' x2='52.67' y2='123.32' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='73.51' x2='52.67' y2='73.51' style='stroke-width: 0.75;' />
+<text x='46.91' y='426.34' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='46.91' y='376.52' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='46.91' y='326.71' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text x='46.91' y='276.89' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text x='46.91' y='227.08' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text x='46.91' y='177.26' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text x='46.91' y='127.45' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='46.91' y='77.64' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='56.99,456.48 495.36,456.48 495.36,69.12 56.99,69.12 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTYuOTl8NDk1LjM2fDY5LjEyfDQ1Ni40OA=='>
+    <rect x='56.99' y='69.12' width='438.37' height='387.36' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTYuOTl8NDk1LjM2fDY5LjEyfDQ1Ni40OA==)'>
+<circle cx='100.75' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='382.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='402.28' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='412.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='332.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='412.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='432.17' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='382.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='332.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='392.32' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='392.32' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='80.11' cy='442.13' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='292.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='332.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='332.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='73.23' cy='412.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='392.32' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='352.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='352.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='402.28' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='392.32' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='332.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='352.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='322.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='382.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='322.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='382.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='432.17' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='422.21' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='432.17' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='392.32' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='412.24' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='342.50' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='327.77' cy='173.14' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='232.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='183.10' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='322.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='222.95' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='382.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='212.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='352.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='282.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='272.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='262.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='252.10' cy='312.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='312.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='292.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='252.84' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='312.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='282.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='262.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='262.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='232.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='212.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='193.06' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='348.41' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='272.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='265.86' cy='322.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.98' cy='322.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='292.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='355.29' cy='272.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='332.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='272.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='312.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='322.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='322.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='262.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='292.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='372.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='312.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='252.84' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='210.82' cy='362.43' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='417.21' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='292.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='163.17' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='222.95' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='458.49' cy='113.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='314.01' cy='382.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='437.85' cy='143.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='153.21' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='222.95' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='232.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='193.06' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='302.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='292.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='232.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='222.95' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='103.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='479.12' cy='103.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='272.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='183.10' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='312.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='103.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='417.21' cy='153.21' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='252.84' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='262.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='232.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='153.21' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='133.28' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='444.73' cy='83.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='232.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='262.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='103.39' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='232.91' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='272.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='183.10' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='183.10' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='292.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='193.06' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='203.02' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='242.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='222.95' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='252.84' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='282.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/legend_top_dynmar_title.svg
+++ b/inst/tinytest/_tinysnapshot/legend_top_dynmar_title.svg
@@ -1,0 +1,235 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='141.28' y='29.09' width='214.25' height='43.20' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<circle cx='152.08' cy='57.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='215.68' cy='57.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='295.29' cy='57.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<text x='248.40' y='43.49' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.69px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text x='162.88' y='62.02' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.00px' lengthAdjust='spacingAndGlyphs'>setosa  </text>
+<text x='226.48' y='62.02' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='58.02px' lengthAdjust='spacingAndGlyphs'>versicolor  </text>
+<text x='306.09' y='62.02' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+<text x='56.99' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='35.19px' lengthAdjust='spacingAndGlyphs'>Hello</text>
+<text x='276.18' y='499.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.36px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,272.30) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.70px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+<line x1='73.23' y1='456.48' x2='486.00' y2='456.48' style='stroke-width: 0.75;' />
+<line x1='73.23' y1='456.48' x2='73.23' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='142.02' y1='456.48' x2='142.02' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='210.82' y1='456.48' x2='210.82' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='279.62' y1='456.48' x2='279.62' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='348.41' y1='456.48' x2='348.41' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='417.21' y1='456.48' x2='417.21' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='486.00' y1='456.48' x2='486.00' y2='460.80' style='stroke-width: 0.75;' />
+<text x='73.23' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='142.02' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='210.82' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='279.62' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='348.41' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='417.21' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='486.00' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='56.99' y1='423.89' x2='56.99' y2='92.30' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='423.89' x2='52.67' y2='423.89' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='376.52' x2='52.67' y2='376.52' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='329.15' x2='52.67' y2='329.15' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='281.78' x2='52.67' y2='281.78' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='234.41' x2='52.67' y2='234.41' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='187.04' x2='52.67' y2='187.04' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='139.67' x2='52.67' y2='139.67' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='92.30' x2='52.67' y2='92.30' style='stroke-width: 0.75;' />
+<text x='46.91' y='428.02' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='46.91' y='380.65' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='46.91' y='333.28' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text x='46.91' y='285.91' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text x='46.91' y='238.54' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text x='46.91' y='191.17' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text x='46.91' y='143.80' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='46.91' y='96.43' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='56.99,456.48 495.36,456.48 495.36,88.13 56.99,88.13 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTYuOTl8NDk1LjM2fDg4LjEzfDQ1Ni40OA=='>
+    <rect x='56.99' y='88.13' width='438.37' height='368.35' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTYuOTl8NDk1LjM2fDg4LjEzfDQ1Ni40OA==)'>
+<circle cx='100.75' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='404.94' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='433.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='80.11' cy='442.84' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='73.23' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='404.94' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='433.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='423.89' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='433.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='395.47' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='414.42' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='348.10' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='327.77' cy='187.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='224.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='357.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='291.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='252.10' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='291.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='224.93' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='205.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='348.41' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='265.86' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.98' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='355.29' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='338.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='329.15' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='376.52' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='210.82' cy='367.04' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='417.21' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='177.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='458.49' cy='130.19' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='314.01' cy='385.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='437.85' cy='158.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='168.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='205.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='310.20' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='479.12' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='319.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='417.21' cy='168.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='168.09' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='149.14' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='444.73' cy='101.77' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='272.30' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='120.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='243.88' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='281.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='196.51' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='300.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='205.99' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='215.46' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='253.36' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='234.41' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='262.83' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='291.25' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/_tinysnapshot/legend_top_dynmar_title_sub.svg
+++ b/inst/tinytest/_tinysnapshot/legend_top_dynmar_title_sub.svg
@@ -1,0 +1,236 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<rect x='141.28' y='47.81' width='214.25' height='43.20' style='stroke-width: 0.75; fill: #FFFFFF;' />
+<circle cx='152.08' cy='76.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='215.68' cy='76.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='295.29' cy='76.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<text x='248.40' y='62.21' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.69px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text x='162.88' y='80.74' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='42.00px' lengthAdjust='spacingAndGlyphs'>setosa  </text>
+<text x='226.48' y='80.74' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='58.02px' lengthAdjust='spacingAndGlyphs'>versicolor  </text>
+<text x='306.09' y='80.74' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+<text x='56.99' y='36.29' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='40.02px' lengthAdjust='spacingAndGlyphs'>Subtitle</text>
+<text x='56.99' y='20.45' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='35.19px' lengthAdjust='spacingAndGlyphs'>Hello</text>
+<text x='276.18' y='499.68' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='67.36px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text transform='translate(12.96,281.66) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='70.70px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+<line x1='73.23' y1='456.48' x2='486.00' y2='456.48' style='stroke-width: 0.75;' />
+<line x1='73.23' y1='456.48' x2='73.23' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='142.02' y1='456.48' x2='142.02' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='210.82' y1='456.48' x2='210.82' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='279.62' y1='456.48' x2='279.62' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='348.41' y1='456.48' x2='348.41' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='417.21' y1='456.48' x2='417.21' y2='460.80' style='stroke-width: 0.75;' />
+<line x1='486.00' y1='456.48' x2='486.00' y2='460.80' style='stroke-width: 0.75;' />
+<text x='73.23' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='142.02' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='210.82' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='279.62' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='348.41' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='417.21' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='486.00' y='478.08' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='56.99' y1='425.55' x2='56.99' y2='110.80' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='425.55' x2='52.67' y2='425.55' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='380.58' x2='52.67' y2='380.58' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='335.62' x2='52.67' y2='335.62' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='290.66' x2='52.67' y2='290.66' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='245.69' x2='52.67' y2='245.69' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='200.73' x2='52.67' y2='200.73' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='155.77' x2='52.67' y2='155.77' style='stroke-width: 0.75;' />
+<line x1='56.99' y1='110.80' x2='52.67' y2='110.80' style='stroke-width: 0.75;' />
+<text x='46.91' y='429.67' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='46.91' y='384.71' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='46.91' y='339.75' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text x='46.91' y='294.79' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<text x='46.91' y='249.82' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>6.5</text>
+<text x='46.91' y='204.86' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.0</text>
+<text x='46.91' y='159.90' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='46.91' y='114.93' text-anchor='end' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='16.67px' lengthAdjust='spacingAndGlyphs'>8.0</text>
+<polygon points='56.99,456.48 495.36,456.48 495.36,106.85 56.99,106.85 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTYuOTl8NDk1LjM2fDEwNi44NXw0NTYuNDg='>
+    <rect x='56.99' y='106.85' width='438.37' height='349.63' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTYuOTl8NDk1LjM2fDEwNi44NXw0NTYuNDg=)'>
+<circle cx='100.75' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='389.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='407.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='416.55' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='344.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='416.55' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='434.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='389.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='344.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='398.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='398.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='80.11' cy='443.53' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='308.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='344.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='344.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='73.23' cy='416.55' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='121.38' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='398.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='362.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='362.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='407.56' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='398.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='344.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='362.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='335.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='389.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='86.99' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='335.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='389.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='434.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='425.55' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='93.87' cy='434.54' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='135.14' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='398.57' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='114.51' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='416.55' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='107.63' cy='353.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='100.75' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<circle cx='327.77' cy='200.73' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='254.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='209.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='335.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='245.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='389.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='236.70' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='362.60' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='299.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='290.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='281.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='252.10' cy='326.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='326.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='308.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='272.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='326.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='299.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='281.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='341.53' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='281.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='254.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='236.70' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='334.65' cy='218.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='348.41' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='290.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='245.22' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='265.86' cy='335.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='258.98' cy='335.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='272.74' cy='308.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='355.29' cy='290.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='344.61' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='314.01' cy='290.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='327.77' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='326.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='335.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='307.13' cy='335.62' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='320.89' cy='281.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='279.62' cy='308.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='231.46' cy='380.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='326.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='293.37' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='300.25' cy='272.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='210.82' cy='371.59' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='286.50' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<circle cx='417.21' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='308.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='191.74' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='245.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='458.49' cy='146.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='314.01' cy='389.58' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='437.85' cy='173.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='182.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='245.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='254.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='218.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='317.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='308.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='369.05' cy='254.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='245.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='137.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='479.12' cy='137.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='290.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='209.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='326.63' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='465.36' cy='137.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='417.21' cy='182.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='272.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='341.53' cy='281.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='254.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='403.45' cy='182.75' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='164.76' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='444.73' cy='119.80' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='254.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='281.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='424.09' cy='137.78' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='382.81' cy='254.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='334.65' cy='290.66' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='209.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='389.69' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='209.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='308.64' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='410.33' cy='218.72' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='396.57' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='227.71' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='348.41' cy='263.68' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='362.17' cy='245.69' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='375.93' cy='272.67' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<circle cx='355.29' cy='299.65' r='2.70' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<polygon points='0.00,504.00 504.00,504.00 504.00,0.00 0.00,0.00 ' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-legend.R
+++ b/inst/tinytest/test-legend.R
@@ -242,3 +242,53 @@ f = function() {
   plt(foo) 
 }
 expect_snapshot_plot(f, label = "legend_custom_s3")
+
+
+# top! + dynmar: title above legend, legend above plot
+
+f = function() {
+  tinyplot(
+    Sepal.Length ~ Petal.Length | Species, data = iris,
+    main = "Hello", legend = list("top!", bty = "o"), theme = "dynamic"
+  )
+  box("outer", lty = 2)
+}
+expect_snapshot_plot(f, label = "legend_top_dynmar_title")
+
+f = function() {
+  tinyplot(
+    Sepal.Length ~ Petal.Length | Species, data = iris,
+    legend = list("top!", bty = "o"), theme = "dynamic"
+  )
+  box("outer", lty = 2)
+}
+expect_snapshot_plot(f, label = "legend_top_dynmar_notitle")
+
+f = function() {
+  tinyplot(
+    Sepal.Length ~ Petal.Length | Species, data = iris,
+    main = "Hello", sub = "Subtitle", legend = list("top!", bty = "o"),
+    theme = "dynamic"
+  )
+  box("outer", lty = 2)
+}
+expect_snapshot_plot(f, label = "legend_top_dynmar_title_sub")
+
+# top! + dynmar: margin reset between successive plots
+f = function() {
+  tinyplot(Sepal.Length ~ Petal.Length | Species, data = iris,
+           legend = list("right!", bty = "o"), theme = "dynamic")
+  tinyplot(Sepal.Length ~ Petal.Length | Species, data = iris,
+           main = "Hello", legend = list("top!", bty = "o"), theme = "dynamic")
+  box("outer", lty = 2)
+}
+expect_snapshot_plot(f, label = "legend_top_dynmar_after_right")
+
+f = function() {
+  tinyplot(Sepal.Length ~ Petal.Length | Species, data = iris,
+           main = "Hello", legend = list("top!", bty = "o"), theme = "dynamic")
+  tinyplot(Sepal.Length ~ Petal.Length | Species, data = iris,
+           legend = list("right!", bty = "o"), theme = "dynamic")
+  box("outer", lty = 2)
+}
+expect_snapshot_plot(f, label = "legend_right_dynmar_after_top")

--- a/man/build_legend_env.Rd
+++ b/man/build_legend_env.Rd
@@ -23,7 +23,6 @@ build_legend_env(
   has_cap = FALSE,
   cap_text = NULL,
   new_plot = TRUE,
-  main_lines = 0L,
   dynmar_title_mar = NULL
 )
 }

--- a/man/build_legend_env.Rd
+++ b/man/build_legend_env.Rd
@@ -22,7 +22,9 @@ build_legend_env(
   has_sub = FALSE,
   has_cap = FALSE,
   cap_text = NULL,
-  new_plot = TRUE
+  new_plot = TRUE,
+  main_lines = 0L,
+  dynmar_title_mar = NULL
 )
 }
 \arguments{

--- a/man/draw_legend.Rd
+++ b/man/draw_legend.Rd
@@ -24,7 +24,9 @@ draw_legend(
   cap_text = NULL,
   new_plot = TRUE,
   draw = TRUE,
-  soma_target = NULL
+  soma_target = NULL,
+  main_lines = 0L,
+  dynmar_title_mar = NULL
 )
 }
 \arguments{
@@ -83,6 +85,12 @@ in order to perform the calculations.}
 
 \item{soma_target}{Numeric. Shared outer margin target (in lines) for
 multi-legend alignment. If \code{NULL}, each legend computes its own margin.}
+
+\item{main_lines}{Integer. Number of lines in the main title (0 if none).}
+
+\item{dynmar_title_mar}{Numeric or \code{NULL}. The pre-computed \code{dynmar_computed[3]}
+value for "top!" legends under dynmar themes. When set, the legend margin
+formula uses this directly to ensure correct title positioning.}
 }
 \value{
 No return value, called for side effect of producing a(n empty) plot

--- a/man/draw_legend.Rd
+++ b/man/draw_legend.Rd
@@ -25,7 +25,6 @@ draw_legend(
   new_plot = TRUE,
   draw = TRUE,
   soma_target = NULL,
-  main_lines = 0L,
   dynmar_title_mar = NULL
 )
 }
@@ -85,8 +84,6 @@ in order to perform the calculations.}
 
 \item{soma_target}{Numeric. Shared outer margin target (in lines) for
 multi-legend alignment. If \code{NULL}, each legend computes its own margin.}
-
-\item{main_lines}{Integer. Number of lines in the main title (0 if none).}
 
 \item{dynmar_title_mar}{Numeric or \code{NULL}. The pre-computed \code{dynmar_computed[3]}
 value for "top!" legends under dynmar themes. When set, the legend margin

--- a/man/tinytheme.Rd
+++ b/man/tinytheme.Rd
@@ -127,11 +127,6 @@ tinytheme("clean", gap.axis = 0.5)
 
 If you supply an explicit \code{mgp} value, it is used as-is and the primitives
 are ignored.
-
-\strong{Caveats.} Known \code{tinytheme} limitations include:
-\itemize{
-\item Themes do not work well when \code{legend = "top!"}.
-}
 }
 \examples{
 # Reusable plot function


### PR DESCRIPTION
Fixes #604


### MWE

``` r
pkgload::load_all("~/Documents/Projects/tinyplot/")
#> ℹ Loading tinyplot
plt(bill_dep ~ bill_len | species, penguins, legend = "top!", theme = "dynamic")
```

![](https://i.imgur.com/CWGgYKD.png)<!-- -->

Fancier plot (that I'll add to the gallery)

``` r
plt(
  body_mass ~ bill_len | species, penguins,
  yaxl = ',',
  main = 'A convex hull of penguins',
  sub = 'Species stick together',
  legend = legend('top!', title = NULL),
  theme = "web"
)
plt_add(type = 'chull', fill = 0.1, col = NA)
```

![](https://i.imgur.com/nm8kxll.png)<!-- -->

<sup>Created on 2026-06-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

### Implementation 

Gory details:

  - Pass `dynmar_computed[3]` into the legend system so `tinylegend`'s `recordGraphics` replay produces a `mar[3]` large enough for both the legend and title
  - Update `dynmar_computed[3]` after `draw_legend` so `draw_facet_window` respects the reserved legend space
  - Skip the `oma[3]` += `topmar_epsilon` offset under `dynmar` to achieve exact title positioning matching other legend positions
  - Position subtitle (`side.sub = 3`) above the legend when `"top!"` + `dynmar` is active
  - Fix `restore_margin_inner` to detect "dirty" margins from `par("mar")` directly (the `omd` reset clears oma as a side-effect)
  - Keep `.theme_mar[3]` for `"top!"` (unlike other outer sides which use `oma`)