### PR TITLE
Website tweaks

### DIFF
--- a/R/type_tile.R
+++ b/R/type_tile.R
@@ -151,7 +151,7 @@
 #'
 #' # tip 2: use per-axis tick label scaling (cex) for dense heatmaps
 #' tinyplot(as.matrix(mtcars), type = type_heatmap(scale = "x"), col = "white",
-#'          theme = list("heatmap", cex.yaxs = 0.75, cex.xaxs = 1.5))
+#'          theme = list("heatmap", cex.yaxs = 0.75, cex.xaxs = 1.25))
 #' 
 #' ## restore the default theme
 #' tinytheme()

--- a/altdoc/pkgdown.yml
+++ b/altdoc/pkgdown.yml
@@ -2,7 +2,7 @@ altdoc: 0.7.3
 pandoc: '0'
 pkgdown: 2.1.3
 pkgdown_sha: ~
-last_built: 2026-08-17T18:03:49+0000
+last_built: 2026-08-17T18:20:36+0000
 urls:
   reference: https://grantmcdermott.com/tinyplot/man
   article: https://grantmcdermott.com/tinyplot/vignettes

--- a/altdoc/pkgdown.yml
+++ b/altdoc/pkgdown.yml
@@ -2,7 +2,7 @@ altdoc: 0.7.3
 pandoc: '0'
 pkgdown: 2.1.3
 pkgdown_sha: ~
-last_built: 2026-08-16T22:34:16+0000
+last_built: 2026-08-17T17:44:29+0000
 urls:
   reference: https://grantmcdermott.com/tinyplot/man
   article: https://grantmcdermott.com/tinyplot/vignettes

--- a/altdoc/pkgdown.yml
+++ b/altdoc/pkgdown.yml
@@ -2,7 +2,7 @@ altdoc: 0.7.3
 pandoc: '0'
 pkgdown: 2.1.3
 pkgdown_sha: ~
-last_built: 2026-08-17T17:44:29+0000
+last_built: 2026-08-17T18:03:49+0000
 urls:
   reference: https://grantmcdermott.com/tinyplot/man
   article: https://grantmcdermott.com/tinyplot/vignettes

--- a/altdoc/quarto_website.yml
+++ b/altdoc/quarto_website.yml
@@ -62,6 +62,20 @@ website:
               file: man/tinyplot.qmd
             - text: tinyplot_add
               file: man/tinyplot_add.qmd
+        - section: "Methods"
+          contents:
+            - text: tinyplot.data.frame
+              file: man/tinyplot.data.frame.qmd
+            - text: tinyplot.matrix
+              file: man/tinyplot.matrix.qmd
+            - text: tinyplot.ts
+              file: man/tinyplot.ts.qmd
+        - section: "Themes"
+          contents:
+            - text: tinytheme
+              file: man/tinytheme.qmd
+            - text: tinytheme_register
+              file: man/tinytheme_register.qmd
         - section: "Types"
           contents:
             - text: type_abline
@@ -134,34 +148,18 @@ website:
               file: man/type_violin.qmd
             - text: type_vline
               file: man/type_abline.qmd
-        - section: "Themes"
-          contents:
-            - text: tinytheme
-              file: man/tinytheme.qmd
-            - text: tinytheme_register
-              file: man/tinytheme_register.qmd
         - section: "Utilities"
           contents:
             - text: draw_legend
               file: man/draw_legend.qmd
+            - text: get_saved_par
+              file: man/get_saved_par.qmd
             # - text: tinyAxis
             #   file: man/tinyAxis.qmd
             - text: tinylabel
               file: man/tinylabel.qmd
-        - section: "Options"
-          contents:
             - text: tpar
               file: man/tpar.qmd
-            - text: get_saved_par
-              file: man/get_saved_par.qmd
-        - section: "Methods"
-          contents:
-            - text: tinyplot.data.frame
-              file: man/tinyplot.data.frame.qmd
-            - text: tinyplot.matrix
-              file: man/tinyplot.matrix.qmd
-            - text: tinyplot.ts
-              file: man/tinyplot.ts.qmd
 
 format:
   html:

--- a/altdoc/quarto_website.yml
+++ b/altdoc/quarto_website.yml
@@ -64,84 +64,76 @@ website:
               file: man/tinyplot_add.qmd
         - section: "Types"
           contents:
-            - section: Shapes
-              contents:
-                - text: type_area
-                  file: man/type_ribbon.qmd
-                - text: type_errorbar
-                  file: man/type_errorbar.qmd
-                - text: type_jitter
-                  file: man/type_jitter.qmd
-                - text: type_lines
-                  file: man/type_lines.qmd
-                - text: type_pointrange
-                  file: man/type_errorbar.qmd
-                - text: type_points
-                  file: man/type_points.qmd
-                - text: type_polygon
-                  file: man/type_polygon.qmd
-                - text: type_polypath
-                  file: man/type_polypath.qmd
-                - text: type_rect
-                  file: man/type_rect.qmd
-                - text: type_ribbon
-                  file: man/type_ribbon.qmd
-                - text: type_rug
-                  file: man/type_rug.qmd
-                - text: type_segments
-                  file: man/type_segments.qmd
-                - text: type_text
-                  file: man/type_text.qmd
-                - text: type_tile
-                  file: man/type_tile.qmd
-            - section: "Visualizations"
-              contents:
-                - text: type_barplot
-                  file: man/type_barplot.qmd
-                - text: type_boxplot
-                  file: man/type_boxplot.qmd
-                - text: type_chull
-                  file: man/type_chull.qmd
-                - text: type_density
-                  file: man/type_density.qmd
-                - text: type_ellipse
-                  file: man/type_ellipse.qmd
-                - text: type_heatmap
-                  file: man/type_tile.qmd
-                - text: type_hexbin
-                  file: man/type_hexbin.qmd
-                - text: type_histogram
-                  file: man/type_histogram.qmd
-                - text: type_qq
-                  file: man/type_qq.qmd
-                - text: type_ridge
-                  file: man/type_ridge.qmd
-                - text: type_spineplot
-                  file: man/type_spineplot.qmd
-                - text: type_violin
-                  file: man/type_violin.qmd
-            - section: "Models"
-              contents:
-                - text: type_glm
-                  file: man/type_glm.qmd
-                - text: type_lm
-                  file: man/type_lm.qmd
-                - text: type_loess
-                  file: man/type_loess.qmd
-                - text: type_spline
-                  file: man/type_spline.qmd
-            - section: "Functions"
-              contents:
-                - text: type_abline
-                  file: man/type_abline.qmd
-                - text: type_function
-                  file: man/type_function.qmd
-                - text: type_hline
-                  file: man/type_abline.qmd
-                - text: type_summary
-                  file: man/type_summary.qmd
-                - text: type_vline
-                  file: man/type_abline.qmd
+            - text: type_abline
+              file: man/type_abline.qmd
+            - text: type_area
+              file: man/type_ribbon.qmd
+            - text: type_barplot
+              file: man/type_barplot.qmd
+            - text: type_boxplot
+              file: man/type_boxplot.qmd
+            - text: type_chull
+              file: man/type_chull.qmd
+            - text: type_density
+              file: man/type_density.qmd
+            - text: type_ellipse
+              file: man/type_ellipse.qmd
+            - text: type_errorbar
+              file: man/type_errorbar.qmd
+            - text: type_function
+              file: man/type_function.qmd
+            - text: type_glm
+              file: man/type_glm.qmd
+            - text: type_heatmap
+              file: man/type_tile.qmd
+            - text: type_hexbin
+              file: man/type_hexbin.qmd
+            - text: type_histogram
+              file: man/type_histogram.qmd
+            - text: type_hline
+              file: man/type_abline.qmd
+            - text: type_jitter
+              file: man/type_jitter.qmd
+            - text: type_lines
+              file: man/type_lines.qmd
+            - text: type_lm
+              file: man/type_lm.qmd
+            - text: type_loess
+              file: man/type_loess.qmd
+            - text: type_pointrange
+              file: man/type_errorbar.qmd
+            - text: type_points
+              file: man/type_points.qmd
+            - text: type_polygon
+              file: man/type_polygon.qmd
+            - text: type_polypath
+              file: man/type_polypath.qmd
+            - text: type_qq
+              file: man/type_qq.qmd
+            - text: type_rect
+              file: man/type_rect.qmd
+            - text: type_ribbon
+              file: man/type_ribbon.qmd
+            - text: type_ridge
+              file: man/type_ridge.qmd
+            - text: type_rug
+              file: man/type_rug.qmd
+            - text: type_segments
+              file: man/type_segments.qmd
+            - text: type_spineplot
+              file: man/type_spineplot.qmd
+            - text: type_spline
+              file: man/type_spline.qmd
+            - text: type_summary
+              file: man/type_summary.qmd
+            - text: type_text
+              file: man/type_text.qmd
+            - text: type_tile
+              file: man/type_tile.qmd
+            - text: type_violin
+              file: man/type_violin.qmd
+            - text: type_vline
+              file: man/type_abline.qmd
         - section: "Themes"
           contents:
             - text: tinytheme

--- a/altdoc/quarto_website.yml
+++ b/altdoc/quarto_website.yml
@@ -25,8 +25,6 @@ website:
             file: vignettes/tips.qmd
           - text: useR! 2025
             file: vignettes/useR2025/useR2025.qmd
-      - text: Gallery
-        file: vignettes/gallery.qmd
       - text: About
         menu:
           - text: News
@@ -37,6 +35,8 @@ website:
             file: $ALTDOC_LICENSE
       - text: Reference
         file: man/tinyplot.qmd
+      - text: Gallery
+        file: vignettes/gallery.qmd
     right:
       - icon: github
         href: $ALTDOC_PACKAGE_URL_GITHUB

--- a/man/type_tile.Rd
+++ b/man/type_tile.Rd
@@ -202,7 +202,7 @@ tinyplot(as.matrix(mtcars), type = type_heatmap(scale = "x"), col = "white")
 
 # tip 2: use per-axis tick label scaling (cex) for dense heatmaps
 tinyplot(as.matrix(mtcars), type = type_heatmap(scale = "x"), col = "white",
-         theme = list("heatmap", cex.yaxs = 0.75, cex.xaxs = 1.5))
+         theme = list("heatmap", cex.yaxs = 0.75, cex.xaxs = 1.25))
 
 ## restore the default theme
 tinytheme()

--- a/vignettes/gallery_figs/heatmap-mtcars.R
+++ b/vignettes/gallery_figs/heatmap-mtcars.R
@@ -5,8 +5,6 @@ m = as.matrix(mtcars)
 plt(
     m,
     type = type_heatmap(scale = "x"),
-    main = "mtcars heatmap",
-    cap = "Note: Values are normalised within each x-axis category",
     col = "white",
-    theme = list("heatmap", cex.yaxs = 0.5, cex.xaxs = 1.5)
+    theme = list("heatmap", cex.yaxs = 0.75, cex.xaxs = 1.25)
 )


### PR DESCRIPTION
_Inter alia_...

- Move "Gallery" to the end of the main menu navbar
- Consolidate the "Reference" section
  - Drop the "Types" subsections ("Shapes", "Visualizations", etc.) and rather just consolidate into a single alphabetical group. These subsections are confusing if you don't know where to look, as well aesthetically unnecessary IMO since we moved the drop-down menus to the navbar (way back in #413).
  - Merge in the "Options" section into "Utilities"