### PR TITLE
Support gradient lines (continuous "by")

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -155,6 +155,11 @@ related to plot layering. See "Bug fixes" below.
   long list of category names on the y-axis without also shrinking the x-axis.
   Both default to `NULL`, in which case the shared `cex.axis` value is used, so
   existing plots are unaffected. (#677 @grantmcdermott)
+- `type_lines()` and its shortcut equivalents like `"l"` and `"s"` now support a
+  _continuous_ `by` variable, drawing a colour gradient along the line itself
+  rather than reverting to a discrete legend. Useful for trajectories, where a
+  third variable (typically time) orders the path; see the new `?type_lines`
+  examples. (#712 @grantmcdermott)
 - Themes:
   - `"heatmap"` provides a dedicated companion theme to the new `type_tile()`
     and `type_heatmap()` types (see above). The theme removes all axis padding,
@@ -204,7 +209,7 @@ related to plot layering. See "Bug fixes" below.
   to numeric tick labels for every line type except `"p"`.
   (#679 @grantmcdermott)
 - Added layers now align on the category that each row belongs to, rather than
-  on the row's _position_. The latter only coincided with the right answer when
+  on the row's _position_. Thie latter only coincided with the right answer when
   the added layer's rows happened to arrive in ascending order; other rows were
   permuted, and repeated categories collapsed onto a single position.
   (#679 @grantmcdermott)

--- a/R/by_aesthetics.R
+++ b/R/by_aesthetics.R
@@ -15,7 +15,9 @@ by_aesthetics = function(settings) {
   # Detect grouping characteristics
   by_ordered = FALSE
   by_continuous = !null_by && inherits(datapoints$by, c("numeric", "integer"))
-  if (isTRUE(by_continuous) && type %in% c("l", "b", "o", "ribbon", "polygon", "polypath", "boxplot", "chull")) {
+  # The connected line types go through segmented_lines() instead. "b" is
+  # still excluded pending its gap handling.
+  if (isTRUE(by_continuous) && type %in% c("b", "ribbon", "polygon", "polypath", "boxplot", "chull")) {
     # Only warn if a legend would actually be drawn: the reversion to a discrete
     # legend still needs to happen for correct grouping, but it's not worth
     # flagging when the user has suppressed the legend anyway (#656).

--- a/R/type_lines.R
+++ b/R/type_lines.R
@@ -47,6 +47,30 @@
 #'   theme = "socviz"
 #' )
 #' 
+#' # A continuous `by` variable is also supported (as of tinyplot v0.8.0).
+#' # This is particularly useful for trajectories, where a third variable (often
+#' # time) orders the path.
+#' time = seq(0, 8*pi, length.out = 600)
+#' spiral = data.frame(time = time, x = time * cos(time), y = time * sin(time))
+#' tinyplot(
+#'   y ~ x | time, data = spiral,
+#'   type = "l",
+#'   lwd = 2, asp = 1, # optional args
+#'   theme = "clean"
+#' )
+#' 
+#' # The canonical time-path example: the x-z projection of a Lorenz attractor.
+#' step = function(p, i) {
+#'   p + 0.005 * c(
+#'     10 * (p[2] - p[1]),
+#'     p[1] * (28 - p[3]) - p[2],
+#'     p[1] * p[2] - 8/3 * p[3]
+#'   )
+#' }
+#' lz = do.call(rbind, Reduce(step, 1:6000, c(1, 1, 1), accumulate = TRUE))
+#' lorenz = data.frame(time = seq_len(nrow(lz)) * 0.005, x = lz[, 1], z = lz[, 3])
+#' tinyplot(z ~ x | time, data = lorenz, type = "l", theme = "clean")
+#' 
 #' @export
 type_lines = function(type = "l", dodge = 0, fixed.dodge = FALSE, xlevels = NULL, xord = NULL) {
   out = list(

--- a/R/type_lines.R
+++ b/R/type_lines.R
@@ -116,8 +116,45 @@ data_lines = function(dodge = 0, fixed.dodge = FALSE, xlevels = NULL, xord = NUL
 }
 
 
+## auxiliary function for drawing per-segment (gradient) lines
+##
+## lines() strokes a polyline once, so it only honours col[1]. segments() does
+## recycle, so we lag the coordinates instead. Line analogue of
+## segmented_polygon(). Continuous `by` only: per-segment strokes lose their
+## joins and restart the dash pattern.
+segmented_lines = function(x, y, col, lty = 1, lwd = 1, type = "l") {
+    n = length(x)
+    if (n < 2L) return(invisible(NULL))
+    col = rep_len(col, n)
+    if (type %in% c("s", "S")) {
+        # Each step splits into a horizontal and a vertical half.
+        if (type == "s") {
+            x0 = c(rbind(x[-n], x[-1L]))
+            y0 = c(rbind(y[-n], y[-n]))
+            x1 = c(rbind(x[-1L], x[-1L]))
+            y1 = c(rbind(y[-n], y[-1L]))
+        } else {
+            x0 = c(rbind(x[-n], x[-n]))
+            y0 = c(rbind(y[-n], y[-1L]))
+            x1 = c(rbind(x[-n], x[-1L]))
+            y1 = c(rbind(y[-1L], y[-1L]))
+        }
+        icol = c(rbind(col[-n], col[-n]))
+    } else {
+        x0 = x[-n]
+        y0 = y[-n]
+        x1 = x[-1L]
+        y1 = y[-1L]
+        icol = col[-n]
+    }
+    # NAs propagate into adjacent segments, which segments() skips silently.
+    segments(x0 = x0, y0 = y0, x1 = x1, y1 = y1,
+             col = icol, lty = lty, lwd = lwd)
+}
+
 draw_lines = function(type = "l") {
-    fun = function(ix, iy, icol, ipch, ibg, ilty, ilwd, icex = 1, flip = FALSE, ...) {
+    fun = function(ix, iy, icol, ipch, ibg, ilty, ilwd, icex = 1, flip = FALSE,
+                   by_continuous = FALSE, ...) {
         ltype = type
         if (isTRUE(flip)) {
             # flip_datapoints() has already swapped the coordinates, but the
@@ -143,6 +180,21 @@ draw_lines = function(type = "l") {
                 ltype = "s"
             }
         }
+        # Continuous `by` gives one colour per observation; lines() would
+        # drop all but the first.
+        if (isTRUE(by_continuous) && length(icol) > 1L &&
+            ltype %in% c("l", "o", "s", "S")) {
+            segmented_lines(
+                x = ix, y = iy, col = icol,
+                lty = ilty, lwd = ilwd, type = ltype
+            )
+            if (ltype == "o") {
+                points(x = ix, y = iy, col = icol, pch = ipch,
+                       bg = ibg, cex = icex)
+            }
+            return(invisible(NULL))
+        }
+
         lines(
             x = ix,
             y = iy,

--- a/altdoc/pkgdown.yml
+++ b/altdoc/pkgdown.yml
@@ -2,7 +2,7 @@ altdoc: 0.7.3
 pandoc: 3.10.2
 pkgdown: 2.1.3
 pkgdown_sha: ~
-last_built: 2026-08-29T04:35:36+0000
+last_built: 2026-09-05T20:50:52+0000
 urls:
   reference: https://grantmcdermott.com/tinyplot/man
   article: https://grantmcdermott.com/tinyplot/vignettes

--- a/inst/tinytest/_tinysnapshot/legend_gradient_line_segments.svg
+++ b/inst/tinytest/_tinysnapshot/legend_gradient_line_segments.svg
@@ -1,0 +1,112 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='504.00pt' height='504.00pt' viewBox='0 0 504.00 504.00'>
+<g class='svglite'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+    .svglite g.glyphgroup path {
+      fill: inherit;
+      stroke: none;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='504.00' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<image width='18.00' height='86.40' x='452.48' y='205.84' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAABkCAYAAABHLFpgAAAAo0lEQVQYlXWLS1LDQAwFW62yA2GRKk7BQTgPx8+CzGhYYDtxPptX/V5LfH/9DCsDS3GkWCkOY6FKsWdgVywDW4pN8ZKBF8XfBM8pnhVbBuIWd/U/2Il8JWQvWCliV29ivNrG4xabyIHEE2FtH/Uo4glZCFexbmHhKQo/o/AUHT8sPEbhexS+2fEQHQ9RC803tNbZhjO1bNMmpmg4ca0dp1ju/gCmb0eaNdB1fgAAAABJRU5ErkJggg=='/>
+<text x='470.48' y='290.26' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='23.34px' lengthAdjust='spacingAndGlyphs'> 100</text>
+<text x='470.48' y='268.44' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='23.34px' lengthAdjust='spacingAndGlyphs'> 200</text>
+<text x='470.48' y='246.62' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='23.34px' lengthAdjust='spacingAndGlyphs'> 300</text>
+<text x='470.48' y='225.68' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='23.34px' lengthAdjust='spacingAndGlyphs'> 400</text>
+<text x='470.48' y='290.26' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.98px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='470.48' y='268.44' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.98px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='470.48' y='246.62' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.98px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='470.48' y='225.68' text-anchor='end' style='font-size: 12.00px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='17.98px' lengthAdjust='spacingAndGlyphs'>-   -</text>
+<text x='452.48' y='191.44' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw0MzUuMjB8MC4wMHw1MDQuMDA='>
+    <rect x='0.00' y='0.00' width='435.20' height='504.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw0MzUuMjB8MC4wMHw1MDQuMDA=)'>
+<text x='247.12' y='34.47' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: "Liberation Sans";' textLength='219.14px' lengthAdjust='spacingAndGlyphs'>Gradient legend (line segments)</text>
+<text x='247.12' y='485.28' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(12.96,244.80) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='23.34px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+</g>
+<g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
+<line x1='116.34' y1='430.56' x2='383.51' y2='430.56' style='stroke-width: 0.75;' />
+<line x1='116.34' y1='430.56' x2='116.34' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='205.40' y1='430.56' x2='205.40' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='294.46' y1='430.56' x2='294.46' y2='437.76' style='stroke-width: 0.75;' />
+<line x1='383.51' y1='430.56' x2='383.51' y2='437.76' style='stroke-width: 0.75;' />
+<text x='116.34' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='205.40' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='294.46' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='383.51' y='456.48' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>5</text>
+<line x1='59.04' y1='422.66' x2='59.04' y2='129.89' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='422.66' x2='51.84' y2='422.66' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='349.46' x2='51.84' y2='349.46' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='276.27' x2='51.84' y2='276.27' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='203.08' x2='51.84' y2='203.08' style='stroke-width: 0.75;' />
+<line x1='59.04' y1='129.89' x2='51.84' y2='129.89' style='stroke-width: 0.75;' />
+<text transform='translate(41.76,422.66) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text transform='translate(41.76,349.46) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text transform='translate(41.76,276.27) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text transform='translate(41.76,203.08) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(41.76,129.89) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: "Liberation Sans";' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>30</text>
+<polygon points='59.04,430.56 435.20,430.56 435.20,59.04 59.04,59.04 ' style='stroke-width: 0.75;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8NDM1LjIwfDU5LjA0fDQzMC41Ng=='>
+    <rect x='59.04' y='59.04' width='376.16' height='371.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8NDM1LjIwfDU5LjA0fDQzMC41Ng==)'>
+<line x1='171.56' y1='261.63' x2='194.27' y2='261.63' style='stroke-width: 0.75; stroke: #31C76E;' />
+<line x1='194.27' y1='261.63' x2='144.84' y2='235.29' style='stroke-width: 0.75; stroke: #31C76E;' />
+<line x1='144.84' y1='235.29' x2='224.55' y2='255.78' style='stroke-width: 0.75; stroke: #91D64D;' />
+<line x1='224.55' y1='255.78' x2='244.58' y2='295.30' style='stroke-width: 0.75; stroke: #00A192;' />
+<line x1='244.58' y1='295.30' x2='246.37' y2='304.09' style='stroke-width: 0.75; stroke: #006E93;' />
+<line x1='246.37' y1='304.09' x2='256.16' y2='359.71' style='stroke-width: 0.75; stroke: #00B08A;' />
+<line x1='256.16' y1='359.71' x2='222.32' y2='211.86' style='stroke-width: 0.75; stroke: #006E93;' />
+<line x1='222.32' y1='211.86' x2='218.76' y2='235.29' style='stroke-width: 0.75; stroke: #4FCB68;' />
+<line x1='218.76' y1='235.29' x2='244.58' y2='287.98' style='stroke-width: 0.75; stroke: #5ECE62;' />
+<line x1='244.58' y1='287.98' x2='244.58' y2='308.48' style='stroke-width: 0.75; stroke: #10C573;' />
+<line x1='244.58' y1='308.48' x2='300.69' y2='328.97' style='stroke-width: 0.75; stroke: #10C573;' />
+<line x1='300.69' y1='328.97' x2='270.41' y2='315.80' style='stroke-width: 0.75; stroke: #009895;' />
+<line x1='270.41' y1='315.80' x2='274.86' y2='346.54' style='stroke-width: 0.75; stroke: #009895;' />
+<line x1='274.86' y1='346.54' x2='405.78' y2='416.80' style='stroke-width: 0.75; stroke: #009895;' />
+<line x1='405.78' y1='416.80' x2='421.27' y2='416.80' style='stroke-width: 0.75; stroke: #44286E;' />
+<line x1='421.27' y1='416.80' x2='414.24' y2='353.86' style='stroke-width: 0.75; stroke: #3F3073;' />
+<line x1='414.24' y1='353.86' x2='134.15' y2='94.76' style='stroke-width: 0.75; stroke: #353E7B;' />
+<line x1='134.15' y1='94.76' x2='82.06' y2='124.03' style='stroke-width: 0.75; stroke: #B7DC39;' />
+<line x1='82.06' y1='124.03' x2='101.65' y2='72.80' style='stroke-width: 0.75; stroke: #BCDD37;' />
+<line x1='101.65' y1='72.80' x2='157.75' y2='254.31' style='stroke-width: 0.75; stroke: #C2DE34;' />
+<line x1='157.75' y1='254.31' x2='251.71' y2='342.14' style='stroke-width: 0.75; stroke: #7FD355;' />
+<line x1='251.71' y1='342.14' x2='244.14' y2='346.54' style='stroke-width: 0.75; stroke: #008398;' />
+<line x1='244.14' y1='346.54' x2='280.21' y2='374.35' style='stroke-width: 0.75; stroke: #008A98;' />
+<line x1='280.21' y1='374.35' x2='280.65' y2='287.98' style='stroke-width: 0.75; stroke: #007294;' />
+<line x1='280.65' y1='287.98' x2='110.55' y2='169.41' style='stroke-width: 0.75; stroke: #00578A;' />
+<line x1='110.55' y1='169.41' x2='128.81' y2='188.44' style='stroke-width: 0.75; stroke: #B7DC39;' />
+<line x1='128.81' y1='188.44' x2='72.97' y2='124.03' style='stroke-width: 0.75; stroke: #7FD355;' />
+<line x1='72.97' y1='124.03' x2='220.54' y2='337.75' style='stroke-width: 0.75; stroke: #A2D945;' />
+<line x1='220.54' y1='337.75' x2='184.92' y2='280.66' style='stroke-width: 0.75; stroke: #007294;' />
+<line x1='184.92' y1='280.66' x2='256.16' y2='349.46' style='stroke-width: 0.75; stroke: #57CD65;' />
+<line x1='256.16' y1='349.46' x2='185.81' y2='255.78' style='stroke-width: 0.75; stroke: #008C98;' />
+</g>
+</g>
+</svg>

--- a/inst/tinytest/test-legend-gradient.R
+++ b/inst/tinytest/test-legend-gradient.R
@@ -48,7 +48,15 @@ f = function() tinyplot(
 )
 expect_snapshot_plot(f, label = "legend_gradient_bg_scalar")
 
+f = function() tinyplot(
+  mpg ~ wt | disp, mtcars,
+  type = "l",
+  main = "Gradient legend (line segments)"
+)
+expect_snapshot_plot(f, label = "legend_gradient_line_segments")
+
 # check overrides ----
 
-# discrete override with warning for certain types (e.g. "l")
-expect_warning(tinyplot(mpg ~ wt | disp, mtcars, type = "l"))
+# discrete override with warning for the types that still can't carry a
+# per-observation colour (e.g. "b", whose gap handling isn't wired up yet)
+expect_warning(tinyplot(mpg ~ wt | disp, mtcars, type = "b"))

--- a/inst/tinytest/test-legend.R
+++ b/inst/tinytest/test-legend.R
@@ -303,11 +303,11 @@ expect_snapshot_plot(f, label = "legend_right_dynmar_after_top")
 # The "continuous legend not supported" warning still fires for a continuous
 # `by` on an unsupported type ...
 expect_warning(
-  plt(mpg ~ wt | cyl, mtcars, type = "l"),
+  plt(mpg ~ wt | cyl, mtcars, type = "b"),
   "Continuous"
 )
 # ... but not when the legend is suppressed (#656): the internal reversion to
 # discrete grouping still happens, so only the (moot) warning is skipped.
 expect_silent(
-  plt(mpg ~ wt | cyl, mtcars, type = "l", legend = FALSE)
+  plt(mpg ~ wt | cyl, mtcars, type = "b", legend = FALSE)
 )

--- a/man/type_lines.Rd
+++ b/man/type_lines.Rd
@@ -120,4 +120,28 @@ tinyplot(
   theme = "socviz"
 )
 
+# A continuous `by` variable is also supported (as of tinyplot v0.8.0).
+# This is particularly useful for trajectories, where a third variable (often
+# time) orders the path.
+time = seq(0, 8*pi, length.out = 600)
+spiral = data.frame(time = time, x = time * cos(time), y = time * sin(time))
+tinyplot(
+  y ~ x | time, data = spiral,
+  type = "l",
+  lwd = 2, asp = 1, # optional args
+  theme = "clean"
+)
+
+# The canonical time-path example: the x-z projection of a Lorenz attractor.
+step = function(p, i) {
+  p + 0.005 * c(
+    10 * (p[2] - p[1]),
+    p[1] * (28 - p[3]) - p[2],
+    p[1] * p[2] - 8/3 * p[3]
+  )
+}
+lz = do.call(rbind, Reduce(step, 1:6000, c(1, 1, 1), accumulate = TRUE))
+lorenz = data.frame(time = seq_len(nrow(lz)) * 0.005, x = lz[, 1], z = lz[, 3])
+tinyplot(z ~ x | time, data = lorenz, type = "l", theme = "clean")
+
 }

--- a/vignettes/gallery.qmd
+++ b/vignettes/gallery.qmd
@@ -94,6 +94,20 @@ Click on a plot to get the link to its code.
 ```{r}
 #| lightbox:
 #|   group: r-graph
+#|   description: "[Code](https://github.com/grantmcdermott/tinyplot/blob/main/vignettes/gallery_figs/line-spiral.R){target='_blank'}"
+#| file: "gallery_figs/line-spiral.R"
+```
+
+```{r}
+#| lightbox:
+#|   group: r-graph
+#|   description: "[Code](https://github.com/grantmcdermott/tinyplot/blob/main/vignettes/gallery_figs/line-lorenz.R){target='_blank'}"
+#| file: "gallery_figs/line-lorenz.R"
+```
+
+```{r}
+#| lightbox:
+#|   group: r-graph
 #|   description: "[Code](https://github.com/grantmcdermott/tinyplot/blob/main/vignettes/gallery_figs/hist-by-penguins.R){target='_blank'}"
 #| file: "gallery_figs/hist-by-penguins.R"
 ```

--- a/vignettes/gallery_figs/line-lorenz.R
+++ b/vignettes/gallery_figs/line-lorenz.R
@@ -1,0 +1,23 @@
+library(tinyplot)
+
+## the canonical time-path: the x-z projection of a Lorenz attractor, where the
+## colour gradient is the only thing separating one pass from the next (#711)
+step = function(p, i) {
+  p + 0.005 * c(
+    10 * (p[2] - p[1]),
+    p[1] * (28 - p[3]) - p[2],
+    p[1] * p[2] - 8/3 * p[3]
+  )
+}
+lz = do.call(rbind, Reduce(step, 1:6000, c(1, 1, 1), accumulate = TRUE))
+lorenz = data.frame(time = seq_len(nrow(lz)) * 0.005, x = lz[, 1], z = lz[, 3])
+
+plt(
+  z ~ x | time,
+  data = lorenz,
+  type = "l",
+  lwd = 2,
+  xlab = NA, ylab = NA, legend = FALSE,
+  main = "Lorenz attractor",
+  theme = list("dark", grid = FALSE, xaxt = "n", yaxt = "n")
+)

--- a/vignettes/gallery_figs/line-lorenz.R
+++ b/vignettes/gallery_figs/line-lorenz.R
@@ -1,7 +1,7 @@
 library(tinyplot)
 
 ## the canonical time-path: the x-z projection of a Lorenz attractor, where the
-## colour gradient is the only thing separating one pass from the next (#711)
+## colour gradient is the only thing separating one pass from the next
 step = function(p, i) {
   p + 0.005 * c(
     10 * (p[2] - p[1]),

--- a/vignettes/gallery_figs/line-spiral.R
+++ b/vignettes/gallery_figs/line-spiral.R
@@ -1,7 +1,7 @@
 library(tinyplot)
 
 ## a continuous `by` variable colours the line itself, rather than splitting
-## it into groups (#711)
+## it into groups
 time = seq(0, 10*pi, length.out = 800)
 spiral = data.frame(time = time, x = time * cos(time), y = time * sin(time))
 

--- a/vignettes/gallery_figs/line-spiral.R
+++ b/vignettes/gallery_figs/line-spiral.R
@@ -1,0 +1,17 @@
+library(tinyplot)
+
+## a continuous `by` variable colours the line itself, rather than splitting
+## it into groups (#711)
+time = seq(0, 10*pi, length.out = 800)
+spiral = data.frame(time = time, x = time * cos(time), y = time * sin(time))
+
+plt(
+  y ~ x | time,
+  data = spiral,
+  type = "l",
+  lwd = 3,
+  asp = 1,
+  xlab = NA, ylab = NA,
+  main = "Archimedean spiral",
+  theme = "clean"
+)


### PR DESCRIPTION
This PR borrows an idea that I used for the gradient "ridges" fills; this time with vectorised segments instead of polygons.

The _tl;dr_ is that we can now use a continuous "by" with line types, which enables some fun plots:

``` r
library("tinyplot")
tinytheme("clean")

time = seq(0, 8*pi, length.out = 600)
spiral = data.frame(time = time, x = time * cos(time), y = time * sin(time))
plt(y ~ x | time, data = spiral, type = "l", lwd = 2, asp = 1)
```

![](https://i.imgur.com/9gK3tyf.png)<!-- -->

``` r
step = function(p, i) {
  p + 0.005 * c(
    10 * (p[2] - p[1]),
    p[1] * (28 - p[3]) - p[2],
    p[1] * p[2] - 8/3 * p[3]
  )
}
lz = do.call(rbind, Reduce(step, 1:6000, c(1, 1, 1), accumulate = TRUE))
lorenz = data.frame(time = seq_len(nrow(lz)) * 0.005, x = lz[, 1], z = lz[, 3])
plt(z ~ x | time, data = lorenz, type = "l", lwd = 2, main = "Lorenz attractor")
```

![](https://i.imgur.com/q4bgzs3.png)<!-- -->

<sup>Created on 2026-09-05 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>